### PR TITLE
Enable Microsoft CLA bot for external PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "Microsoft CLA"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  contents: write # Required to store CLA signatures
+  pull-requests: write # Required to comment on PRs
+  statuses: write # Required to set CLA status check
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Microsoft CLA Assistant"
+        if: |
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+           (github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://cla.opensource.microsoft.com/microsoft/azure-container-linux"
+          branch: "aclmain"
+          allowlist: "bot*,*[bot],microsoft-github-operations-bot,dependabot*,msftbot,azure-pipelines-bot"
+          lock-pullrequest-aftermerge: true


### PR DESCRIPTION
Task - https://dev.azure.com/mariner-org/ACL/_workitems/edit/20352

- Add .github/workflows/cla.yml to run Microsoft CLA check on PRs
- Update CONTRIBUTING.md with CLA requirement documentation
- Allowlist bot accounts and Microsoft org members
- CLA signatures stored in signatures/version1/cla.json

Inspiration - https://github.com/contributor-assistant/github-action#configure-contributor-license-agreement-within-two-minutes

Azl3 uses the Microsoft CLA bot GitHub App directly. The bot runs the license/cla status check automatically on PRs without needing any workflow file in the repo. If we want to match Azl3 exactly, we would need to remove the cla.yml and just have the Microsoft CLA GitHub App installed on the repo (admin set up). The workflow approach is a fallback that works without the app.