### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run '...'
+2. Configure '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+- OS/Image version: [e.g. Azure Container Linux 3.0.20260501]
+- Architecture: [e.g. x86_64, arm64]
+- Platform: [e.g. Azure, QEMU]
+
+**Logs / Screenshots**
+If applicable, add logs, screenshots, or command output to help explain the problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+## Summary <!-- REQUIRED -->
+<!-- Quick explanation of the changes. What does the PR accomplish, why was it needed? -->
+
+
+## Change Log <!-- REQUIRED -->
+<!-- Detail the changes made here. -->
+<!-- List any packages, images, or sysexts affected by this change. -->
+- Change
+- Change
+
+## Type of Change <!-- REQUIRED -->
+<!-- Check all that apply -->
+- [ ] Image build change (base image, sysexts, OEM images)
+- [ ] Package/SPEC update
+- [ ] CI/automation change
+- [ ] SDK/toolchain update
+- [ ] Configuration change
+- [ ] Documentation update
+- [ ] Bug fix
+
+## Does this affect the image build? <!-- REQUIRED -->
+<!-- Consider if this change impacts the base image, sysexts, SDK, or build pipeline. -->
+- [ ] Yes
+- [ ] No
+
+## Associated Issues <!-- optional -->
+<!-- Link to GitHub issues if possible. -->
+<!-- Use "fixes #xxxx" to auto-close an associated issue once the PR is merged. -->
+<!-- - fixes #xxxx -->
+
+## Test Methodology <!-- REQUIRED -->
+<!-- How was this validated? e.g. local image build, SDK container build, kola tests, pipeline run, etc. -->
+- Test details:
+
+<!--
+These HTML comments are not rendered in the PR description.
+Feel free to delete sections that do not apply to your PR, or add additional details.
+-->
+
+## Merge Checklist <!-- REQUIRED -->
+<!-- You can set them now ([x]) or set them later using the GitHub UI -->
+**All applicable** boxes should be checked before merging
+- [ ] Image builds successfully with this change (or image build is not affected)
+- [ ] Any updated packages/SPECs build successfully
+- [ ] Relevant kola tests pass
+- [ ] All package sources are available
+- [ ] Source files have up-to-date hashes/manifests
+- [ ] Documentation has been updated to match any changes
+- [ ] Ready to merge


### PR DESCRIPTION
Task - https://dev.azure.com/mariner-org/ACL/_workitems/edit/20357

Add GitHub templates following the pattern used in microsoft/azurelinux:
- PR template with summary, changelog, type of change, test methodology, and merge checklist
- Bug report issue template with environment details
- Feature request issue template