### PR TITLE
Move CODEOWNERS to .github/ and fix team reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file defines who is responsible for code review
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @microsoft/teams/azure-container-linux
+* @microsoft/azure-container-linux


### PR DESCRIPTION
## Changes
- Move CODEOWNERS from repo root to `.github/CODEOWNERS` (GitHub recommended location)
- Fix invalid team reference: `@microsoft/teams/azure-container-linux` → `@microsoft/azure-container-linux`