### PR TITLE
Revert "Bring recent fixes up to 2026-06-04 (#6)"

### DIFF
--- a/acl/tests/kola_enforcing.yaml
+++ b/acl/tests/kola_enforcing.yaml
@@ -26,22 +26,16 @@ tests:
       - platforms: [qemu]
         architectures: [aarch64]
         reason: 3-node etcd cluster on TCG-emulated arm64 races systemd's DefaultDeviceTimeoutSec for /dev/disk/by-label/OEM; tracked by the OEM fsck conditional dropin work
-      - platforms: [azure]
-        reason: Azure version depends on discovery.etcd.io, which is unmaintained.
 
   - name: acl.flannel.udp
     exceptions:
       - architectures: [aarch64]
         reason: Flannel UDP coverage is registered only for amd64
-      - platforms: [azure]
-        reason: Azure version depends on discovery.etcd.io, which is unmaintained.
   - name: acl.flannel.vxlan
     exceptions:
       - platforms: [qemu]
         architectures: [aarch64]
         reason: Flakiness on TCG-emulated arm64 in aclmain, failures due to slow device enumeration.
-      - platforms: [azure]
-        reason: Azure version depends on discovery.etcd.io, which is unmaintained.
 
   - name: acl.internet
     exceptions:
@@ -96,9 +90,6 @@ tests:
 
   - name: cl.etcd-member.etcdctlv3
   - name: cl.etcd-member.v2-backup-restore
-    exceptions:
-      - platforms: [azure]
-        reason: Azure version depends on discovery.etcd.io, which is unmaintained.
 
   - name: cl.filesystem
     exceptions:

--- a/acl/tests/run-selinux-toggle-test.sh
+++ b/acl/tests/run-selinux-toggle-test.sh
@@ -44,28 +44,22 @@ boot_id() {
     ssh_cmd 'cat /proc/sys/kernel/random/boot_id' 2>/dev/null
 }
 
-# Set (or remove) the tag on the VM, then wait for in-guest IMDS to converge.
-#
-# Uses the generic ARM tag endpoint (`az tag update`) rather than
-# `az vm update --set tags.…`. The latter round-trips the whole VM resource
-# through the Compute RP, so it can fail on unrelated VM properties.
+# Set (or remove) the tag on the VM, then wait for in-guest IMDS to converge
 set_selinux_tag() {
     local value="$1"
-    local vm_id
-    vm_id=$(az vm show --resource-group "$VM_RG" --name "$VM_NAME" --query id -o tsv)
     if [[ -z "$value" ]]; then
         info "Removing acl-node-security-profile tag..."
-        az tag update \
-            --resource-id "$vm_id" \
-            --operation delete \
-            --tags "acl-node-security-profile=" \
+        az vm update \
+            --resource-group "$VM_RG" \
+            --name "$VM_NAME" \
+            --remove tags.acl-node-security-profile \
             --output none
     else
         info "Setting acl-node-security-profile=${value}..."
-        az tag update \
-            --resource-id "$vm_id" \
-            --operation merge \
-            --tags "acl-node-security-profile=${value}" \
+        az vm update \
+            --resource-group "$VM_RG" \
+            --name "$VM_NAME" \
+            --set "tags.acl-node-security-profile=${value}" \
             --output none
     fi
     info "Waiting for in-guest IMDS to report tag='${value:-<absent>}'..."

--- a/build_library/rpm/package_catalog.yaml
+++ b/build_library/rpm/package_catalog.yaml
@@ -30,7 +30,6 @@ packages:
     - selinux-policy
     - policycoreutils
     - ca-certificates
-    - irqbalance
   sys-libs/systemd-libs: systemd-libs
   sys-apps/systemd-networkd: systemd-networkd
   net-misc/systemd-networkd: systemd-networkd


### PR DESCRIPTION
Reverts the batched commit f929d374c9 so we can bring each fix individually as separate PRs for cleaner history:

- PR 27634: fix: use `az tag update` in SELinux toggle test
- PR 27637: enforcing: exempt discovery.etcd.io-dependent tests on Azure
- PR 27647: add irqbalance pkg in base image

These will be re-landed as individual commits.