### PR TITLE
fix: use 'az tag update' in SELinux toggle test

### DIFF
--- a/acl/tests/run-selinux-toggle-test.sh
+++ b/acl/tests/run-selinux-toggle-test.sh
@@ -44,22 +44,28 @@ boot_id() {
     ssh_cmd 'cat /proc/sys/kernel/random/boot_id' 2>/dev/null
 }
 
-# Set (or remove) the tag on the VM, then wait for in-guest IMDS to converge
+# Set (or remove) the tag on the VM, then wait for in-guest IMDS to converge.
+#
+# Uses the generic ARM tag endpoint (`az tag update`) rather than
+# `az vm update --set tags.…`. The latter round-trips the whole VM resource
+# through the Compute RP, so it can fail on unrelated VM properties.
 set_selinux_tag() {
     local value="$1"
+    local vm_id
+    vm_id=$(az vm show --resource-group "$VM_RG" --name "$VM_NAME" --query id -o tsv)
     if [[ -z "$value" ]]; then
         info "Removing acl-node-security-profile tag..."
-        az vm update \
-            --resource-group "$VM_RG" \
-            --name "$VM_NAME" \
-            --remove tags.acl-node-security-profile \
+        az tag update \
+            --resource-id "$vm_id" \
+            --operation delete \
+            --tags "acl-node-security-profile=" \
             --output none
     else
         info "Setting acl-node-security-profile=${value}..."
-        az vm update \
-            --resource-group "$VM_RG" \
-            --name "$VM_NAME" \
-            --set "tags.acl-node-security-profile=${value}" \
+        az tag update \
+            --resource-id "$vm_id" \
+            --operation merge \
+            --tags "acl-node-security-profile=${value}" \
             --output none
     fi
     info "Waiting for in-guest IMDS to report tag='${value:-<absent>}'..."


### PR DESCRIPTION
azure-cli 2.87.0 wired zone-movement into az vm update (Azure/azure-cli#33242). The new PUT body trips a BadRequest from regions/subs where zone movement isn't enabled, breaking our tag flip. Switch to az tag update, which hits the generic ARM tag endpoint and doesn't touch the Compute provider.

Original-PR: 27634
Co-authored-by: Nikola Bojanic <nbojanic@microsoft.com>