### PR TITLE
feat: add irqbalance pkg in base image

### DIFF
--- a/build_library/rpm/package_catalog.yaml
+++ b/build_library/rpm/package_catalog.yaml
@@ -30,6 +30,7 @@ packages:
     - selinux-policy
     - policycoreutils
     - ca-certificates
+    - irqbalance
   sys-libs/systemd-libs: systemd-libs
   sys-apps/systemd-networkd: systemd-networkd
   net-misc/systemd-networkd: systemd-networkd


### PR DESCRIPTION
Add irqbalance to the ACL base image package catalog for interrupt balancing across CPUs.

Original-PR: 27647
Co-authored-by: Mayank Singh <mayansingh@microsoft.com>