### PR TITLE
feat: emit rpmdb sidecar artifact for IC usage

### DIFF
--- a/build_library/rpm/build_image_util.sh
+++ b/build_library/rpm/build_image_util.sh
@@ -1425,6 +1425,19 @@ finish_image_backup_etc_rpm() {
     # Also remove the manually-created Nvidia repo file and any leftovers
     sudo rm -rf "${root_fs_dir}/etc/yum.repos.d"
 
+    # Emit the rpmdb as an IC sidecar artifact alongside the VHD.
+    local rpmdb_src="${root_fs_dir}/var/lib/rpm/rpmdb.sqlite"
+    if [[ -f "${rpmdb_src}" ]]; then
+        if [[ -z "${BUILD_DIR:-}" ]]; then
+            die "RPM mode: BUILD_DIR is not set — cannot save rpmdb IC sidecar"
+        fi
+        info "RPM mode: Saving rpmdb IC sidecar to ${BUILD_DIR}/acl_production_image_rpmdb.sqlite"
+        sudo cp "${rpmdb_src}" "${BUILD_DIR}/acl_production_image_rpmdb.sqlite" \
+            || die "RPM mode: Failed to save rpmdb sidecar to ${BUILD_DIR}"
+        sudo chmod 644 "${BUILD_DIR}/acl_production_image_rpmdb.sqlite" \
+            || die "RPM mode: Failed to chmod rpmdb sidecar"
+    fi
+
     # Bulk-copy all of /etc to ${DISTRO_SHARE_DIR}/etc.
     # This is the overlay lowerdir — at boot, /etc is a tmpfs overlay
     # whose lower layer is this directory.  Mirrors the Portage-mode

--- a/build_library/rpm/rpm_install.sh
+++ b/build_library/rpm/rpm_install.sh
@@ -51,15 +51,15 @@ rpm_query_manifest() {
 # Initialize RPM database in target rootfs
 rpm_init_database() {
     local root_fs_dir="$1"
+    local dbpath_fs="${root_fs_dir}/var/lib/rpm"
 
-    if [[ -d "${root_fs_dir}/var/lib/rpm" ]] && [[ -f "${root_fs_dir}/var/lib/rpm/rpmdb.sqlite" ]]; then
+    if [[ -f "${dbpath_fs}/rpmdb.sqlite" ]]; then
         info "RPM database already initialized in ${root_fs_dir}"
         return 0
     fi
 
     info "Initializing RPM database in ${root_fs_dir}"
-    sudo mkdir -p "${root_fs_dir}/var/lib/rpm"
-
+    sudo mkdir -p "${dbpath_fs}"
     sudo rpm --root="${root_fs_dir}" --initdb
     if [[ $? -ne 0 ]]; then
         error "Failed to initialize RPM database"
@@ -529,9 +529,8 @@ rpm_get_metadata() {
     local package="$2"
     local key="$3"
     local dbpath="${root_fs_dir}/var/lib/rpm"
-
-    local format=""
-    case "$key" in
+    local format
+    case "${key}" in
         LICENSE) format="%{LICENSE}" ;;
         HOMEPAGE) format="%{URL}" ;;
         VERSION) format="%{VERSION}" ;;

--- a/build_sysext
+++ b/build_sysext
@@ -243,7 +243,7 @@ info "Building '${SYSEXTNAME}' squashfs with (meta-)packages '${@}' in '${BUILD_
 # Unlike Portage (one dir per package), RPM uses a single DB file that gets
 # fully copied-up by overlayfs on any write, so rpm -qa after install returns
 # base + new packages. Snapshot here to diff later.
-if [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]] && [[ -d "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm" ]]; then
+if [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]] && [[ -f "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm/rpmdb.sqlite" ]]; then
   rpm --root="${BUILD_DIR}/${FLAGS_install_root_basename}" -qa 2>/dev/null | sort > "${BUILD_DIR}/.rpm-base.tmp"
   rpm_query_manifest "${BUILD_DIR}/${FLAGS_install_root_basename}" | sort > "${BUILD_DIR}/.rpm-base-manifest.tmp"
 fi
@@ -328,7 +328,7 @@ if [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]]; then
   # actual contents when an RPM database is present.
   touch "${BUILD_DIR}/${SYSEXTNAME}_packages.txt"
   # Diff against pre-install snapshot to list only sysext-added packages.
-  if [[ -d "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm" ]]; then
+  if [[ -f "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm/rpmdb.sqlite" ]]; then
     rpm --root="${BUILD_DIR}/${FLAGS_install_root_basename}" -qa 2>/dev/null | sort > "${BUILD_DIR}/.rpm-all.tmp"
     rpm_query_manifest "${BUILD_DIR}/${FLAGS_install_root_basename}" | sort > "${BUILD_DIR}/.rpm-all-manifest.tmp"
     # comm -13: output lines unique to the right file (i.e. newly installed packages only)


### PR DESCRIPTION
Emit the RPM database (`rpmdb.sqlite`) as an IC sidecar artifact (`acl_production_image_rpmdb.sqlite`) alongside the VHD in RPM build mode, so package state is preserved for downstream image-customization steps.

Also tightens RPM database existence checks to test for the `rpmdb.sqlite` file directly instead of the `var/lib/rpm` directory in `build_sysext` and `rpm_install.sh`.

Original-PR: 27776