### PR TITLE
fix(coreos-init): derive UKI addon dir from kernel version in flatcar-reset

### DIFF
--- a/acl/SPECS/coreos-init/coreos-init.spec
+++ b/acl/SPECS/coreos-init/coreos-init.spec
@@ -1,6 +1,6 @@
 Name:           coreos-init
 Version:        0.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Init scripts for Flatcar (systemd units, scripts, configs)
 
 License:        BSD-3-Clause
@@ -100,6 +100,12 @@ find %{buildroot} -type f -o -type l \
 %doc README.md
 
 %changelog
+* Mon Jun 29 2026 Jiri Appl <jiria@microsoft.com> - 0.0.1-4
+- Fix support-UKI-mode-by-restoring-firstboot-addon patch to derive the UKI
+  addon directory from the kernel version (vmlinuz-<version>.efi.extra.d)
+  instead of the obsolete acl.efi.extra.d, so flatcar-reset correctly detects
+  UKI mode and re-arms the firstboot (Ignition) addon.
+
 * Tue May 06 2026 Mayank Singh <mayansingh@microsoft.com> - 0.0.1-3
 - Add patch: flatcar-autologin-generator uses provisioned user instead of
   hardcoded core. Fixes getty failures on ACL Phase 2 where core has

--- a/acl/SPECS/coreos-init/support-UKI-mode-by-restoring-firstboot-addon.patch
+++ b/acl/SPECS/coreos-init/support-UKI-mode-by-restoring-firstboot-addon.patch
@@ -32,7 +32,7 @@ index 1acfcf0..18768d8 100755
  
  [ "$EUID" = "0" ] || { echo "Need to be root: sudo $0 $opts" > /dev/stderr ; exit 1 ; }
  
-+UKI_ADDON_DIR="/boot/EFI/Linux/acl.efi.extra.d"
++UKI_ADDON_DIR="/boot/EFI/Linux/vmlinuz-$(uname -r).efi.extra.d"
 +UKI_ADDON_TEMPLATE="/boot/acl/uki-addons/firstboot.addon.efi"
 +
 +# Detect UKI (systemd-boot) mode by the presence of the addon directory.


### PR DESCRIPTION
Cherry-pick of ADO PR 27985 onto the public mirror.

The `support-UKI-mode-by-restoring-firstboot-addon` patch hardcoded the UKI addon dir as `/boot/EFI/Linux/acl.efi.extra.d`. ACL UKIs now use UAPI naming (`vmlinuz-<version>.efi`), so that path never exists — `is_uki_mode()` always returned false and `flatcar-reset` silently skipped re-arming the firstboot (Ignition) addon on UKI images.

**Fix:** derive the dir from `$(uname -r)` so it matches the actual UKI name. All three uses (`is_uki_mode`, `--stop` cleanup, restore) reference the variable, so the single change fixes the whole flow. Bumps `coreos-init.spec` Release 3 → 4.

Companion to the doc fix in #20.

Original-PR: 27985