### PR TITLE
fix: use arch-specific QEMU VM boot timeouts

### DIFF
--- a/acl/build_rpm_image.sh
+++ b/acl/build_rpm_image.sh
@@ -23,7 +23,7 @@
 #   --az-region=REGION                   Azure region to override default (for start-vm --vm-type=azure)
 #   --az-vm-size=SIZE                    Azure VM size (default: Standard_D2s_v5)
 #   --board=BOARD                        Target board (default: amd64-usr)
-#   --boot-timeout=SECS                  Timeout waiting for VM boot (default: 180)
+#   --boot-timeout=SECS                  Timeout waiting for VM boot (default: arch-based — amd64 100s, arm64 300s)
 #   --build-rpms                         Build custom RPM packages using Azure Linux toolkit (runs acl/build.sh)
 #   --build-sdk-container                Update/rebuild SDK container with RPM tools (can run standalone)
 #   --build-standalone-sysexts[=TAG,...]  Build standalone sysexts (all, or only those matching any given tag)
@@ -98,7 +98,7 @@
 #   USE_SERIAL_CONSOLE      Use serial console (true) or SSH (false) - default: true
 #   VM_CONSOLE_USER         Serial console login user (default: root)
 #   VM_CONSOLE_PASSWORD     Serial console login password
-#   VM_BOOT_TIMEOUT         Boot timeout in seconds (default: 180)
+#   VM_BOOT_TIMEOUT         Boot timeout in seconds (default: arch-based — amd64 100s, arm64 300s)
 #   VM_SSH_KEY              SSH private key path
 #   VM_SSH_TIMEOUT          SSH connection timeout in seconds (default: 120)
 #
@@ -143,7 +143,7 @@ VM_PASSWORD="${VM_PASSWORD:-}"  # Password for VM user (optional)
 USE_SERIAL_CONSOLE="${USE_SERIAL_CONSOLE:-false}"  # Use serial console instead of SSH
 VM_CONSOLE_USER="${VM_CONSOLE_USER:-root}"  # Console login user
 VM_CONSOLE_PASSWORD="${VM_CONSOLE_PASSWORD:-}"  # Console login password (empty for no password)
-VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT:-180}"  # Seconds to wait for VM boot
+VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT:-}"  # Empty = auto-select by arch in validate (amd64 vs arm64)
 RUN_KOLA_TESTS=false  # Run kola tests (qemu via run_local_tests.sh, azure via run_azure_tests.sh)
 ACG_IMAGE_VERSION_ID=""  # Pre-existing Azure Compute Gallery image version resource ID (bypasses VHD upload)
 REUSE_IMAGE=false  # Reuse the latest published gallery image (skip VHD upload)
@@ -1355,7 +1355,7 @@ main() {
         validate_args+=("--vm-type=${VM_TYPE}")
         validate_args+=("--vm-name=${VM_NAME}")
         validate_args+=("--ssh-timeout=${VM_SSH_TIMEOUT}")
-        validate_args+=("--boot-timeout=${VM_BOOT_TIMEOUT}")
+        [[ -n "${VM_BOOT_TIMEOUT}" ]] && validate_args+=("--boot-timeout=${VM_BOOT_TIMEOUT}")
         validate_args+=("--console-user=${VM_CONSOLE_USER}")
         [[ -n "${AZ_SUB_ID:-}" ]] && validate_args+=("--az-sub-id=${AZ_SUB_ID}")
         [[ -n "${AZ_REGION:-}" ]] && validate_args+=("--az-region=${AZ_REGION}")

--- a/acl/validate/validate_common.sh
+++ b/acl/validate/validate_common.sh
@@ -41,7 +41,13 @@ VM_PASSWORD="${VM_PASSWORD:-}"  # Password for VM user (optional)
 USE_SERIAL_CONSOLE="${USE_SERIAL_CONSOLE:-false}"  # Use serial console instead of SSH
 VM_CONSOLE_USER="${VM_CONSOLE_USER:-root}"  # Console login user
 VM_CONSOLE_PASSWORD="${VM_CONSOLE_PASSWORD:-}"  # Console login password (empty for no password)
-VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT:-180}"  # Seconds to wait for VM boot
+# VM boot timeout is arch-dependent: emulated arm64 (TCG) boots far slower than
+# native amd64, so it needs a much higher ceiling. The effective value is chosen
+# by resolve_boot_timeout() based on BOARD unless VM_BOOT_TIMEOUT / --boot-timeout
+# is set explicitly (an explicit value always wins).
+VM_BOOT_TIMEOUT_AMD64="${VM_BOOT_TIMEOUT_AMD64:-100}"  # Native boot: seconds to wait
+VM_BOOT_TIMEOUT_ARM64="${VM_BOOT_TIMEOUT_ARM64:-300}"  # Emulated boot: seconds to wait
+VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT:-}"  # Explicit override; empty = auto-select by arch
 SECURE_BOOT_ENABLED="${SECURE_BOOT_ENABLED:-true}"  # Enable secure boot
 RUN_KOLA_TESTS=false  # Run kola tests (qemu via run_local_tests.sh, azure via run_azure_tests.sh)
 ACG_IMAGE_VERSION_ID=""  # Pre-existing Azure Compute Gallery image version resource ID
@@ -711,7 +717,7 @@ parse_validate_args() {
                 echo ""
                 echo "Options:"
                 echo "  --board=BOARD              Target board (default: amd64-usr)"
-                echo "  --boot-timeout=SECS        Timeout waiting for VM boot (default: 180)"
+                echo "  --boot-timeout=SECS        Timeout waiting for VM boot (default: arch-based — amd64 ${VM_BOOT_TIMEOUT_AMD64}s, arm64 ${VM_BOOT_TIMEOUT_ARM64}s)"
 
                 echo "  --console-password=PASS    Serial console login password"
                 echo "  --console-user=USER        Serial console login user (default: root)"
@@ -757,8 +763,23 @@ parse_validate_args() {
 
 # ── Main entry point ──────────────────────────────────────────────
 
+# Select an arch-appropriate VM boot timeout when the caller hasn't pinned one.
+# Emulated arm64 boots take far longer than native amd64; a single fixed timeout
+# is either too tight for arm64 (flaky boot failures) or wastefully loose for amd64.
+resolve_boot_timeout() {
+    [[ -n "${VM_BOOT_TIMEOUT}" ]] && return 0  # explicit env / --boot-timeout wins
+
+    local arch="${BOARD%%-*}"  # arm64-usr -> arm64, amd64-usr -> amd64
+    case "$arch" in
+        arm64|aarch64) VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT_ARM64}" ;;
+        *)             VM_BOOT_TIMEOUT="${VM_BOOT_TIMEOUT_AMD64}" ;;
+    esac
+    info "Using VM boot timeout for ${arch}: ${VM_BOOT_TIMEOUT}s"
+}
+
 validate_main() {
     parse_validate_args "$@"
+    resolve_boot_timeout
 
     # Source platform module now that VM_TYPE is known from arg parsing
     case "$VM_TYPE" in

--- a/acl/validate/validate_rpm_image.sh
+++ b/acl/validate/validate_rpm_image.sh
@@ -24,7 +24,7 @@
 #   --az-region=REGION                   Azure region to override default
 #   --az-vm-size=SIZE                    Azure VM size (default: Standard_D2s_v5)
 #   --board=BOARD                        Target board (default: amd64-usr)
-#   --boot-timeout=SECS                  Timeout waiting for VM boot (default: 180)
+#   --boot-timeout=SECS                  Timeout waiting for VM boot (default: arch-based — amd64 100s, arm64 300s)
 #   --build-vm-image                     Build VM images before starting
 #   --console-password=PASS              Serial console login password (empty for passwordless)
 #   --console-user=USER                  Serial console login user (default: root)
@@ -68,7 +68,7 @@
 # Environment Variables:
 #   ACL_SDK_IMAGE           Override SDK container image
 #   NO_TTY                  Set to "true" to disable TTY allocation (for CI)
-#   VM_BOOT_TIMEOUT         Boot timeout in seconds (default: 180)
+#   VM_BOOT_TIMEOUT         Boot timeout in seconds (default: arch-based — amd64 100s, arm64 300s)
 #   VM_SSH_USER             SSH user for VM (default: core)
 #   VM_SSH_KEY              SSH private key path
 #   VM_SSH_TIMEOUT          SSH connection timeout in seconds (default: 120)


### PR DESCRIPTION
Select the QEMU VM boot timeout by architecture instead of a single fixed 180s, fixing flaky arm64 QEMU smoke-test boot failures.

Emulated arm64 (TCG) VMs boot far slower than native amd64. Across recent builds the "Qemu VM Boot" smoke test runs ~19-28s on amd64 but clusters near 180-250s on arm64, producing marginal-timeout boot failures at the 180s ceiling.

- `validate/validate_common.sh`: add per-arch defaults `VM_BOOT_TIMEOUT_AMD64=100` and `VM_BOOT_TIMEOUT_ARM64=300`; `VM_BOOT_TIMEOUT` now defaults to empty and a new `resolve_boot_timeout()` (called at the top of `validate_main`) picks the value from `BOARD`. An explicit `VM_BOOT_TIMEOUT` env var or `--boot-timeout` flag still overrides.
- `build_rpm_image.sh`: default left empty; only forwards `--boot-timeout` to the validate script when explicitly set, keeping `validate_common.sh` the single source of truth.
- Update help/usage docs in the three affected scripts.

Original-PR: 27944
Co-authored-by: Jiri Appl <Jiri.Appl@microsoft.com>