### PR TITLE
test(kola): add kdump enforcing tests and harden crash kernel config

### DIFF
--- a/acl/tests/kola_enforcing.yaml
+++ b/acl/tests/kola_enforcing.yaml
@@ -54,6 +54,18 @@ tests:
           does not SNAT ICMP. Revert once mantle/infra restores outbound ICMP
           (NSG-on-NIC keeping the PIP, or a NAT Gateway on the kola subnet).
 
+  - name: acl.kdump
+    exceptions:
+      - bootloader: [grub]
+        reason: acl.kdump requires UKI boot (addon-based crashkernel)
+
+  - name: acl.kdump.grub
+    exceptions:
+      - platforms: [azure]
+        reason: writing /oem/grub.cfg does not persist across reboot on cloud platforms.
+      - bootloader: [uki]
+        reason: acl.kdump.grub is for GRUB images only
+
   - name: acl.ignition.v1.users
   - name: acl.ignition.v2.users
 

--- a/build_library/rpm/build_image_util.sh
+++ b/build_library/rpm/build_image_util.sh
@@ -872,15 +872,16 @@ TMPFILES_KDUMP
 
     # Ensure /etc/kdump.conf exists with a default config.
     # kdumpctl expects this file to determine the dump target.
-    # dracut_args --tmpdir /var/crash: use ext4 ROOT partition for dracut's
-    #   scratch space instead of /tmp (tmpfs) to avoid tmpfs space pressure
-    #   when building the kdump initramfs.
+    # dracut_args:
+    #   --tmpdir /var/crash: use ext4 ROOT for dracut scratch (avoids tmpfs pressure)
+    #   -o "setup-root ignition": crash kernel cannot mount dm-verity /usr, so
+    #     these modules must be excluded to prevent emergency.target on aarch64
     sudo tee "${root_fs_dir}/etc/kdump.conf" > /dev/null <<'KDUMP_CONF'
 # kdump configuration for ACL
 # Dump to local filesystem
 path /var/crash
 core_collector makedumpfile -l --message-level 7 -d 31
-dracut_args --tmpdir /var/crash
+dracut_args --tmpdir /var/crash -o "setup-root ignition"
 KDUMP_CONF
 
     # kdumpctl constructs the kernel path as:
@@ -899,6 +900,9 @@ KDUMP_CONF
 # The kernel is copied here by the kdump.service ExecStartPre drop-in.
 KDUMP_BOOTDIR="/var/crash"
 KDUMP_IMG="vmlinuz"
+# Crash kernel cmdline: nr_cpus=1 avoids SMP hang on aarch64,
+# irqpoll + reset_devices ensure stable device access post-panic.
+KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices"
 KDUMP_SYSCONFIG
 }
 


### PR DESCRIPTION
Enable `acl.kdump` and `acl.kdump.grub` as enforcing kola tests, with bootloader/platform exceptions, and harden the crash kernel config.

**Kola tests (`acl/tests/kola_enforcing.yaml`)**
- `acl.kdump` — excepted on GRUB (requires UKI boot for addon-based crashkernel).
- `acl.kdump.grub` — GRUB-only: excepted on UKI, and on azure where `/oem/grub.cfg` does not persist across reboot.

**Crash kernel config (`build_library/rpm/build_image_util.sh`)**
- `dracut_args` now exclude `setup-root ignition` so the crash kernel avoids dm-verity `/usr` mounts that trigger `emergency.target` on aarch64.
- Add `KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices"` to avoid an SMP hang on aarch64 and ensure stable device access post-panic.

Original-PR: 27990

Co-authored-by: Mayank Singh <mayansingh@microsoft.com>