### PR TITLE
fix(validate): preserve --tag RESOURCE_TAGS so azure smoke VM RGs get cleaned up

### DIFF
--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -30,7 +30,11 @@ AZ_GALLERY_RG="${AZ_GALLERY_RG:?Must be set — resource group for Azure Compute
 AZ_ACG="${AZ_ACG:?Must be set — Azure Compute Gallery name}"
 NO_CLEANUP="${NO_CLEANUP:-false}"
 BUILD_ID="${BUILD_ID:-}"
-RESOURCE_TAGS=("createdBy=$(whoami)")
+# Only default when empty — don't clobber the buildId/adoProject/arch tags that
+# validate_common.sh parsed from --tag (the pipeline's per-run RG cleanup needs them).
+if [[ -z "${RESOURCE_TAGS+x}" || ${#RESOURCE_TAGS[@]} -eq 0 ]]; then
+    RESOURCE_TAGS=("createdBy=$(whoami)")
+fi
 VM_RG_PREFIX="${VM_RG_PREFIX:-$(whoami)-acl-test-vm-rg}"
 VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"


### PR DESCRIPTION
The Azure smoke test provisions a throwaway VM in its own resource group and is meant to delete it when the run ends. That delete was silently a no-op, so RGs leaked.

The pipeline passes `buildId` / `adoProject` / `arch` as `--tag` values, which `validate_common.sh` parses into `RESOURCE_TAGS`. It then sources `validate_azure.sh`, whose top-level `RESOURCE_TAGS=(createdBy=...)` line overwrote that list, so the RG was tagged only `createdBy` / `purpose` / `creationTime`. The per-run cleanup deletes RGs matching `buildId && adoProject && arch`, matched nothing, and the RG survived until the daily janitor swept it.

Make the default assignment conditional so it only seeds `createdBy` when no tags were parsed instead of overwriting. The `buildId` / `adoProject` / `arch` tags now stay on the RG, so the per-run cleanup deletes it immediately. Standalone use (no `--tag`) still gets the `createdBy` default.

Original-PR: 28041
Co-authored-by: Aadhar Agarwal <aadagarwal@microsoft.com>