### PR TITLE
add exception to acl.kdump and acl.kdump.grub for qemu + aarch64

### DIFF
--- a/acl/tests/kola_enforcing.yaml
+++ b/acl/tests/kola_enforcing.yaml
@@ -90,21 +90,23 @@ tests:
           as linux.ntp). Covered by the containerd and chrony follow-up
           tests tracked there.
 
-  # TEMPORARY (AB#22249): acl.kdump and acl.kdump.grub are disabled on the ACL
-  # distro in mantle (ExcludeDistros: [acl]), so kola never selects them and the
-  # "enforced test NOT SELECTED" check fails. Restore both entries when the
-  # mantle-side ExcludeDistros is dropped.
-  # - name: acl.kdump
-  #   exceptions:
-  #     - bootloader: [grub]
-  #       reason: acl.kdump requires UKI boot (addon-based crashkernel)
-  #
-  # - name: acl.kdump.grub
-  #   exceptions:
-  #     - platforms: [azure]
-  #       reason: writing /oem/grub.cfg does not persist across reboot on cloud platforms.
-  #     - bootloader: [uki]
-  #       reason: acl.kdump.grub is for GRUB images only
+  - name: acl.kdump
+    exceptions:
+      - bootloader: [grub]
+        reason: acl.kdump requires UKI boot (addon-based crashkernel)
+      - platforms: [qemu]
+        architectures: [aarch64]
+        reason: Crash dump under TCG emulation is too slow and I/O-variable to be reliable, aarch64 coverage via Azure.
+
+  - name: acl.kdump.grub
+    exceptions:
+      - platforms: [azure]
+        reason: writing /oem/grub.cfg does not persist across reboot on cloud platforms.
+      - bootloader: [uki]
+        reason: acl.kdump.grub is for GRUB images only
+      - platforms: [qemu]
+        architectures: [aarch64]
+        reason: Crash dump under TCG emulation is too slow and I/O-variable to be reliable.
 
   - name: acl.ignition.v1.users
   - name: acl.ignition.v2.users

--- a/acl/tests/kola_enforcing.yaml
+++ b/acl/tests/kola_enforcing.yaml
@@ -96,7 +96,7 @@ tests:
         reason: acl.kdump requires UKI boot (addon-based crashkernel)
       - platforms: [qemu]
         architectures: [aarch64]
-        reason: Crash dump under TCG emulation is too slow and I/O-variable to be reliable, aarch64 coverage via Azure.
+        reason: Crash dump under TCG emulation is too slow and I/O-variable to be reliable.
 
   - name: acl.kdump.grub
     exceptions:


### PR DESCRIPTION
## Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. What does the PR accomplish, why was it needed? -->
add exception to acl.kdump for qemu + aarch64

## Change Log <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- List any packages, images, or sysexts affected by this change. -->
- add exception to acl.kdump for qemu + aarch64

## Type of Change <!-- REQUIRED -->
<!-- Check all that apply -->
- [ ] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [x] Configuration change
- [ ] Documentation update
- [ ] Bug fix

## Does this affect the image build? <!-- REQUIRED -->
<!-- Consider if this change impacts the base image, sysexts, SDK, or build pipeline. -->
- [ ] Yes
- [x] No

## Associated Issues <!-- optional -->
<!-- Link to GitHub issues if possible. -->
<!-- Use "fixes #xxxx" to auto-close an associated issue once the PR is merged. -->
<!-- - fixes https://dev.azure.com/mariner-org/ACL/_workitems/edit/22250
https://dev.azure.com/mariner-org/ACL/_workitems/edit/22249


## Test Methodology <!-- REQUIRED -->
<!-- How was this validated? e.g. local image build, SDK container build, kola tests, pipeline run, etc. -->
- Test details: https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1197962&view=results

<!--
These HTML comments are not rendered in the PR description.
Feel free to delete sections that do not apply to your PR, or add additional details.
-->

## Merge Checklist <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the GitHub UI -->
**All applicable** boxes should be checked before merging
- [x] Image builds successfully with this change (or image build is not affected)
- [ ] Any updated packages/SPECs build successfully
- [x] Relevant kola tests pass
- [ ] All package sources are available
- [ ] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [x] Ready to merge
