### PR TITLE
Increase UKI ESP size from 128 MiB to 256 MiB

### DIFF
--- a/build_library/disk_layout_uki.json
+++ b/build_library/disk_layout_uki.json
@@ -13,7 +13,7 @@
                 "label": "EFI-SYSTEM",
                 "fs_label": "EFI-SYSTEM",
                 "type": "efi",
-                "blocks": "262144",
+                "blocks": "524288",
                 "fs_type": "vfat",
                 "mount": "/boot",
                 "features": []


### PR DESCRIPTION
The ARM64 UKI is ~82 MiB (vs ~49 MiB on AMD64). A/B updates stage the new UKI on the ESP alongside the running one, requiring room for two. The 128 MiB ESP (262144 blocks) overflows on ARM64 (No space left on device, os error 28, copying UKI to ESP). Double to 256 MiB (524288 blocks) to fit two ~82 MiB UKIs plus bootloaders with headroom. Stays 4096-block aligned.


Copilot-Session: 72f4b84a-8f5c-4df6-9f8e-fb4850c520e2

## Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. What does the PR accomplish, why was it needed? -->


## Change Log <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- List any packages, images, or sysexts affected by this change. -->
- Change
- Change

## Type of Change <!-- REQUIRED -->
<!-- Check all that apply -->
- [ ] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [ ] Bug fix

## Does this affect the image build? <!-- REQUIRED -->
<!-- Consider if this change impacts the base image, sysexts, SDK, or build pipeline. -->
- [ ] Yes
- [ ] No

## Associated Issues <!-- optional -->
<!-- Link to GitHub issues if possible. -->
<!-- Use "fixes #xxxx" to auto-close an associated issue once the PR is merged. -->
<!-- - fixes #xxxx -->

## Test Methodology <!-- REQUIRED -->
<!-- How was this validated? e.g. local image build, SDK container build, kola tests, pipeline run, etc. -->
- Test details:

<!--
These HTML comments are not rendered in the PR description.
Feel free to delete sections that do not apply to your PR, or add additional details.
-->

## Merge Checklist <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the GitHub UI -->
**All applicable** boxes should be checked before merging
- [ ] Image builds successfully with this change (or image build is not affected)
- [ ] Any updated packages/SPECs build successfully
- [ ] Relevant kola tests pass
- [ ] All package sources are available
- [ ] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [ ] Ready to merge
