### PR TITLE
uki: add arm64 test-image device-timeout addon

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -555,6 +555,7 @@ install_oem_package() {
             "${oem_files_dir}"
         if [[ "${BOOTLOADER_MODE}" == "uki" ]]; then
             install_uki_oem_addon
+            install_uki_timeout_addon
         fi
         return 0
     fi
@@ -600,6 +601,7 @@ install_oem_package() {
     # UKI addon (replacing the role of grub.cfg).
     if [[ "${BOOTLOADER_MODE}" == "uki" ]]; then
         install_uki_oem_addon
+        install_uki_timeout_addon
     fi
 }
 
@@ -754,6 +756,88 @@ install_uki_oem_addon() {
         "${ARCH}" \
         "${VM_TMP_ROOT}" \
         "${oem_files_dir}"
+}
+
+# Build and install a UKI addon that raises the systemd device-init timeout,
+# scoped to the arm64 kola *test* image only (INJECT_DOCKER_SYSEXT=true).
+#
+# Under kola's parallel QEMU-TCG emulation on aarch64, heavy CPU contention can
+# prevent udev from initialising the ESP/OEM/usr-verity devices within the
+# default initrd device timeout, dropping the VM to an emergency shell.  Baking
+# systemd.default_device_timeout_sec=120 into a UKI addon on the test image's
+# ESP fixes this without changing production or amd64 boot behaviour.
+#
+# Deliberately NOT applied to the production VM image (INJECT_DOCKER_SYSEXT=false)
+# or to amd64: the failure is a CI-only TCG-emulation artefact that never occurs
+# on real hardware.
+install_uki_timeout_addon() {
+    if [[ "${BOOTLOADER_MODE}" != "uki" ]]; then
+        return 0
+    fi
+
+    # Scope: arm64 test image only.
+    if [[ "${ARCH}" != "arm64" ]] || [[ "${INJECT_DOCKER_SYSEXT:-false}" != "true" ]]; then
+        return 0
+    fi
+
+    local esp_dir="${VM_TMP_ROOT}/boot"
+    if [[ ! -d "${esp_dir}/EFI/Linux" ]]; then
+        warn "UKI timeout addon: ESP directory ${esp_dir}/EFI/Linux not found; skipping"
+        return 0
+    fi
+
+    # EFI architecture suffix for the systemd-boot stub.
+    local efi_arch
+    case "${ARCH}" in
+        amd64)  efi_arch="x64" ;;
+        arm64)  efi_arch="aa64" ;;
+        *)      warn "UKI timeout addon: unsupported arch ${ARCH}; skipping"; return 0 ;;
+    esac
+
+    local efi_stub="${VM_TMP_ROOT}/usr/lib/systemd/boot/efi/linux${efi_arch}.efi.stub"
+    if [[ ! -f "${efi_stub}" ]]; then
+        warn "UKI timeout addon: EFI stub not found at ${efi_stub}; skipping"
+        return 0
+    fi
+
+    # Detect the main UKI (vmlinuz-<version>.efi) to locate its .extra.d dir.
+    local uki_name
+    uki_name=$(find "${esp_dir}/EFI/Linux/" -maxdepth 1 -name 'vmlinuz-*.efi' -printf '%f\n' | sort -V | head -n 1)
+    if [[ -z "${uki_name}" ]]; then
+        warn "UKI timeout addon: no UKI (vmlinuz-*.efi) found in ESP; skipping"
+        return 0
+    fi
+
+    if ! command -v ukify &>/dev/null; then
+        die "UKI timeout addon: ukify not found on PATH"
+    fi
+
+    info "UKI timeout addon: Building for arm64 test image (${VM_IMG_TYPE})"
+
+    local addon_dir="${esp_dir}/EFI/Linux/${uki_name}.extra.d"
+    sudo mkdir -p "${addon_dir}"
+
+    local timeout_temp_dir
+    timeout_temp_dir=$(mktemp -d)
+
+    printf '%s\n' "systemd.default_device_timeout_sec=120" \
+        > "${timeout_temp_dir}/timeout-cmdline.txt"
+
+    sudo ukify build \
+        --cmdline=@"${timeout_temp_dir}/timeout-cmdline.txt" \
+        --stub="${efi_stub}" \
+        --output="${timeout_temp_dir}/timeout.addon.efi"
+
+    if [[ ! -f "${timeout_temp_dir}/timeout.addon.efi" ]]; then
+        rm -rf "${timeout_temp_dir}"
+        die "UKI timeout addon: ukify failed to produce timeout.addon.efi"
+    fi
+
+    sudo cp "${timeout_temp_dir}/timeout.addon.efi" "${addon_dir}/timeout.addon.efi"
+    info "UKI timeout addon: Installed -> EFI/Linux/${uki_name}.extra.d/timeout.addon.efi"
+    info "UKI timeout addon: cmdline = systemd.default_device_timeout_sec=120"
+
+    rm -rf "${timeout_temp_dir}"
 }
 
 # Any other tweaks required?


### PR DESCRIPTION
Install a UKI addon setting systemd.default_device_timeout_sec=120 on the arm64 kola test image only (gated on ARCH=arm64 and INJECT_DOCKER_SYSEXT=true).

Under kola's parallel QEMU-TCG emulation on aarch64, CPU contention can keep udev from initialising the ESP/OEM/usr-verity devices within the default initrd device timeout, dropping the VM to an emergency shell. Raising the timeout via a test-image ESP addon fixes this. Verified against a parallel=24 repro: 18/18 boot-to-login vs 18/18 emergency shells at baseline.

Scoped to the test image, so production and amd64 boot behaviour is unchanged; the failure is a CI-only emulation artefact that never occurs on real hardware.


Copilot-Session: 72f4b84a-8f5c-4df6-9f8e-fb4850c520e2

## Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. What does the PR accomplish, why was it needed? -->


## Change Log <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- List any packages, images, or sysexts affected by this change. -->
- Change
- Change

## Type of Change <!-- REQUIRED -->
<!-- Check all that apply -->
- [ ] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [ ] Bug fix

## Does this affect the image build? <!-- REQUIRED -->
<!-- Consider if this change impacts the base image, sysexts, SDK, or build pipeline. -->
- [ ] Yes
- [ ] No

## Associated Issues <!-- optional -->
<!-- Link to GitHub issues if possible. -->
<!-- Use "fixes #xxxx" to auto-close an associated issue once the PR is merged. -->
<!-- - fixes #xxxx -->

## Test Methodology <!-- REQUIRED -->
<!-- How was this validated? e.g. local image build, SDK container build, kola tests, pipeline run, etc. -->
- Test details:

<!--
These HTML comments are not rendered in the PR description.
Feel free to delete sections that do not apply to your PR, or add additional details.
-->

## Merge Checklist <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the GitHub UI -->
**All applicable** boxes should be checked before merging
- [ ] Image builds successfully with this change (or image build is not affected)
- [ ] Any updated packages/SPECs build successfully
- [ ] Relevant kola tests pass
- [ ] All package sources are available
- [ ] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [ ] Ready to merge
