### PR TITLE
acl-grub: use dedicated /usr verity hash partitions consistent with UKI; fix arm64 test-image device-init timeout

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -32,22 +32,36 @@
         "fs_type":"btrfs",
         "fs_compression":"zstd",
         "mount":"/usr",
+        "verity_hash":"4",
         "features": ["prioritize", "verity"]
       },
       "4":{
+        "label":"HASH-A",
+        "uuid":"1fae528b-6baf-4efc-a226-2a23f9291ce6",
+        "type":"dps-usr-verity",
+        "blocks":"20480"
+      },
+      "5":{
         "label":"USR-B",
         "uuid":"e03dd35c-7c2d-4a47-b3fe-27f15780a57c",
         "type":"flatcar-rootfs",
         "blocks":"2097152",
-        "fs_blocks":"262144"
+        "fs_blocks":"262144",
+        "verity_hash":"6"
       },
-      "5":{
+      "6":{
+        "label":"HASH-B",
+        "uuid":"accb60b1-1d72-4e05-9363-6fd51e2ce788",
+        "type":"dps-usr-verity",
+        "blocks":"20480"
+      },
+      "7":{
         "label":"ROOT-C",
         "uuid":"d82521b4-07ac-4f1c-8840-ddefedc332f3",
         "type":"blank",
         "blocks":"0"
       },
-      "6":{
+      "8":{
         "label":"OEM",
         "fs_label":"OEM",
         "type":"data",
@@ -56,17 +70,17 @@
         "fs_compression":"zlib",
         "mount":"/oem"
       },
-      "7":{
+      "9":{
         "label":"OEM-CONFIG",
         "type":"flatcar-reserved",
         "blocks":"131072"
       },
-      "8":{
+      "10":{
         "type":"blank",
         "label":"flatcar-reserved",
         "blocks":"0"
       },
-      "9":{
+      "11":{
         "label":"ROOT",
         "fs_label":"ROOT",
         "type":"dps-root",
@@ -76,28 +90,28 @@
       }
     },
     "vm":{
-      "9":{
+      "11":{
         "label":"ROOT",
         "fs_label":"ROOT",
         "blocks":"12943360"
       }
     },
     "azure":{
-      "9":{
+      "11":{
         "label":"ROOT",
         "fs_label":"ROOT",
         "blocks":"58875904"
       }
     },
     "vagrant":{
-      "9":{
+      "11":{
         "label":"ROOT",
         "fs_label":"ROOT",
         "blocks":"33845248"
       }
     },
     "onmetal":{
-      "7":{
+      "9":{
         "label":"config-2",
         "fs_label":"config-2",
         "type":"data",
@@ -130,6 +144,12 @@
         "type":"blank"
       },
       "9":{
+        "type":"blank"
+      },
+      "10":{
+        "type":"blank"
+      },
+      "11":{
         "label":"ROOT",
         "fs_label":"ROOT",
         "type":"0fc63daf-8483-4772-8e79-3d69d8477de4",

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -556,6 +556,8 @@ install_oem_package() {
         if [[ "${BOOTLOADER_MODE}" == "uki" ]]; then
             install_uki_oem_addon
             install_uki_timeout_addon
+        elif [[ "${BOOTLOADER_MODE}" == "grub" ]]; then
+            install_grub_timeout_override
         fi
         return 0
     fi
@@ -602,6 +604,8 @@ install_oem_package() {
     if [[ "${BOOTLOADER_MODE}" == "uki" ]]; then
         install_uki_oem_addon
         install_uki_timeout_addon
+    elif [[ "${BOOTLOADER_MODE}" == "grub" ]]; then
+        install_grub_timeout_override
     fi
 }
 
@@ -849,6 +853,55 @@ install_uki_timeout_addon() {
     info "UKI timeout addon: cmdline = systemd.default_device_timeout_sec=120"
 
     sudo rm -rf "${timeout_temp_dir}"
+}
+
+# Append systemd.default_device_timeout_sec=120 to grub.cfg's shared cmdline,
+# scoped to the arm64 kola *test* image only (INJECT_DOCKER_SYSEXT=true).
+#
+# GRUB has no addon mechanism like UKI's .extra.d, so unlike
+# install_uki_timeout_addon this patches the already-written grub.cfg copies
+# on the ESP directly (both are plain text, no rebuild/re-signing needed) -
+# same CI-only QEMU-TCG device-init timeout this exists to work around.
+#
+# Deliberately NOT applied to the production VM image (INJECT_DOCKER_SYSEXT=false)
+# or to amd64: the failure is a CI-only TCG-emulation artefact that never occurs
+# on real hardware.
+install_grub_timeout_override() {
+    if [[ "${BOOTLOADER_MODE}" != "grub" ]]; then
+        return 0
+    fi
+
+    # Scope: arm64 test image only.
+    if [[ "${ARCH}" != "arm64" ]] || [[ "${INJECT_DOCKER_SYSEXT:-false}" != "true" ]]; then
+        return 0
+    fi
+
+    local esp_dir="${VM_TMP_ROOT}/boot"
+    local -a grub_cfgs=(
+        "${esp_dir}/EFI/boot/grub.cfg"
+        "${esp_dir}/boot/grub2/grub.cfg"
+    )
+
+    local found=0
+    for cfg in "${grub_cfgs[@]}"; do
+        if [[ ! -f "${cfg}" ]]; then
+            continue
+        fi
+        found=1
+        if sudo grep -q 'systemd.default_device_timeout_sec=' "${cfg}"; then
+            info "GRUB timeout override: ${cfg} already patched; skipping"
+            continue
+        fi
+        sudo sed -i 's/^set linux_cmdline="\(.*\)"$/set linux_cmdline="\1 systemd.default_device_timeout_sec=120"/' "${cfg}"
+        info "GRUB timeout override: patched ${cfg}"
+    done
+
+    if [[ "${found}" -eq 0 ]]; then
+        warn "GRUB timeout override: no grub.cfg found under ${esp_dir}; skipping"
+        return 0
+    fi
+
+    info "GRUB timeout override: cmdline += systemd.default_device_timeout_sec=120"
 }
 
 # Any other tweaks required?


### PR DESCRIPTION
Follow-up to #28. GRUB's disk_layout.json still used the legacy single-partition inline-hash verity scheme, but this branch's grub.cfg/grub_install.sh changes switched the verity cmdline to UUID=-based hash identification (dropping hash-offset=), which requires the hash tree to live on its own independently-discoverable partition.

Confirmed via a live acldevel GRUB build: the image built, but hung at boot waiting on `dev-disk-by-uuid-<verity_uuid>.device` (45s timeout, never resolves) since that UUID isn't blkid-discoverable when the hash is inline.

Separately, real-hardware arm64 test runs surfaced a pre-existing GRUB-only gap: under CI's higher kola `--parallel` (QEMU-TCG, no HW acceleration), udev can't always bring up ESP/OEM/usr-verity block devices within systemd's default ~45s device-init timeout, causing verity activation to fail and the image to drop to an emergency shell (`acl.kdump`/`acl.kdump.grub` flaked this way in CI). UKI test images already work around this via `install_uki_timeout_addon()`; GRUB test images had no equivalent since GRUB has no addon mechanism.

## Changes
- `build_library/disk_layout.json`: add dedicated HASH-A/HASH-B partitions (`dps-usr-verity` type) cross-referenced via `verity_hash`, mirroring `disk_layout_uki.json`. ESP stays 128MiB (no AB-staging need on GRUB). BIOS-BOOT partition kept (shared with Portage/flatcar; RPM/GRUB mode already skips installing to it).
- `build_library/vm_image_util.sh`: add `install_grub_timeout_override()` (arm64 test-images only, mirrors `install_uki_timeout_addon()`'s scoping) which patches `systemd.default_device_timeout_sec=120` directly into `grub.cfg`'s `linux_cmdline`, since GRUB has no signed-addon equivalent for kernel-cmdline injection. Wired into both call sites in `install_oem_package()`.

Both fixes verified locally on real KVM hardware (amd64) and on a real Azure VM (arm64, via QEMU-TCG) -- confirmed the timeout hang reproduces reliably at `--parallel=24` against the unpatched image and is fixed by the override, with the kernel arg verified present in the boot console log.

ACL-GRUB still can't do Trident A/B updates (no addon-swap equivalent) -- these changes only fix the partitioning/verity mechanics and arm64 test-image timeout flakiness so GRUB boots and tests correctly, consistent with the UKI scheme instead of silently broken.