### PR TITLE
kola: stop enforcing acl.kdump/acl.kdump.grub while disabled in mantle

### DIFF
--- a/acl/tests/kola_enforcing.yaml
+++ b/acl/tests/kola_enforcing.yaml
@@ -54,17 +54,21 @@ tests:
           does not SNAT ICMP. Revert once mantle/infra restores outbound ICMP
           (NSG-on-NIC keeping the PIP, or a NAT Gateway on the kola subnet).
 
-  - name: acl.kdump
-    exceptions:
-      - bootloader: [grub]
-        reason: acl.kdump requires UKI boot (addon-based crashkernel)
-
-  - name: acl.kdump.grub
-    exceptions:
-      - platforms: [azure]
-        reason: writing /oem/grub.cfg does not persist across reboot on cloud platforms.
-      - bootloader: [uki]
-        reason: acl.kdump.grub is for GRUB images only
+  # TEMPORARY (AB#22249): acl.kdump and acl.kdump.grub are disabled on the ACL
+  # distro in mantle (ExcludeDistros: [acl]), so kola never selects them and the
+  # "enforced test NOT SELECTED" check fails. Restore both entries when the
+  # mantle-side ExcludeDistros is dropped.
+  # - name: acl.kdump
+  #   exceptions:
+  #     - bootloader: [grub]
+  #       reason: acl.kdump requires UKI boot (addon-based crashkernel)
+  #
+  # - name: acl.kdump.grub
+  #   exceptions:
+  #     - platforms: [azure]
+  #       reason: writing /oem/grub.cfg does not persist across reboot on cloud platforms.
+  #     - bootloader: [uki]
+  #       reason: acl.kdump.grub is for GRUB images only
 
   - name: acl.ignition.v1.users
   - name: acl.ignition.v2.users


### PR DESCRIPTION
Stop enforcing `acl.kdump` and `acl.kdump.grub` in `kola_enforcing.yaml` while they are excluded on the `acl` distro in mantle.

- azure-container-linux-mantle#32 adds `ExcludeDistros: ["acl"]` to both tests, so kola no longer selects them on ACL.
- `kola_enforcing.yaml` still listed `acl.kdump` as enforced (with only a `bootloader: [grub]` exception), so on the QEMU/amd64 UKI leg with the `default` kola filter `evaluate_test_results.sh` reported it as an enforced test NOT SELECTED and failed the stage.
- Both entries are commented out with their original exception rules preserved, so they can be restored once the mantle-side `ExcludeDistros` is dropped.

Refs: bug 22249