### PR TITLE
Fix Azure smoke cleanup tags on release/3.0

### DIFF
--- a/.pipelines/github-pr-validation.yml
+++ b/.pipelines/github-pr-validation.yml
@@ -3,8 +3,8 @@
 #                                                                               #
 # Thin entry point for GitHub PR validation, living in the GitHub repo          #
 # (microsoft/azure-container-linux). Triggers on PRs targeting aclmain and      #
-# extends the shared ACL-GitHub-PR.yml template in the acl-pipelines ADO        #
-# repo, which runs the actual build and test.                                   #
+# release branches, and extends the shared ACL-GitHub-PR.yml template in the    #
+# acl-pipelines ADO repo, which runs the actual build and test.                 #
 #                                                                               #
 # Security:                                                                     #
 #   - Fork PRs do NOT get secrets by default (ADO default behavior)             #
@@ -18,6 +18,7 @@ pr:
   branches:
     include:
       - aclmain
+      - release/*
 
 resources:
   repositories:

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -30,7 +30,11 @@ AZ_GALLERY_RG="${AZ_GALLERY_RG:?Must be set — resource group for Azure Compute
 AZ_ACG="${AZ_ACG:?Must be set — Azure Compute Gallery name}"
 NO_CLEANUP="${NO_CLEANUP:-false}"
 BUILD_ID="${BUILD_ID:-}"
-RESOURCE_TAGS=("createdBy=$(whoami)")
+# Only default when empty — don't clobber the buildId/adoProject/arch tags that
+# validate_common.sh parsed from --tag (the pipeline's per-run RG cleanup needs them).
+if [[ -z "${RESOURCE_TAGS+x}" || ${#RESOURCE_TAGS[@]} -eq 0 ]]; then
+    RESOURCE_TAGS=("createdBy=$(whoami)")
+fi
 VM_RG_PREFIX="${VM_RG_PREFIX:-$(whoami)-acl-test-vm-rg}"
 VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"


### PR DESCRIPTION
## Summary

- backport the tag-preservation fix from #24 to `release/3.0`
- preserve `buildId`, `adoProject`, and `arch` tags parsed from `--tag`
- retain the standalone `createdBy=$(whoami)` default when no tags are supplied

## Why

The AMD64 and ARM64 prod nightlies consume `release/3.0`. Its Azure validation module currently overwrites `RESOURCE_TAGS` after argument parsing, so smoke-test resource groups are created without the tags required by both per-run cleanup queries. The smoke suite can pass while both cleanup layers report that no groups were found, leaving live resources until the daily janitor removes them 24-48 hours later.

Confirmed occurrence:
- [ACL bug 22419](https://dev.azure.com/mariner-org/ACL/_workitems/edit/22419)
- [ARM64 nightly 1158935](https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1158935) created `cloudtest-acl-test-vm-rg-cj2l9nus` with only `createdBy`, `purpose`, and `creationTime`
- [Janitor 1160390](https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1160390) removed it 44h 18m later

Source fix: #24 (`ad3f15e680`).

## Validation

- `bash -n acl/validate/validate_azure.sh`
- sourced the module with pipeline tags and verified all four values remain unchanged
- sourced the module without `RESOURCE_TAGS` and verified the standalone `createdBy` default
- `git diff --check`
- verified the resulting file matches the implementation from `ad3f15e680`

`ShellCheck` is not installed in the local environment.