### PR TITLE
ci: run GitHub PR validation on release/* branches

### DIFF
--- a/.pipelines/github-pr-validation.yml
+++ b/.pipelines/github-pr-validation.yml
@@ -3,8 +3,8 @@
 #                                                                               #
 # Thin entry point for GitHub PR validation, living in the GitHub repo          #
 # (microsoft/azure-container-linux). Triggers on PRs targeting aclmain and      #
-# extends the shared ACL-GitHub-PR.yml template in the acl-pipelines ADO        #
-# repo, which runs the actual build and test.                                   #
+# release branches, and extends the shared ACL-GitHub-PR.yml template in the    #
+# acl-pipelines ADO repo, which runs the actual build and test.                 #
 #                                                                               #
 # Security:                                                                     #
 #   - Fork PRs do NOT get secrets by default (ADO default behavior)             #
@@ -18,6 +18,7 @@ pr:
   branches:
     include:
       - aclmain
+      - release/*
 
 resources:
   repositories:


### PR DESCRIPTION
The `pr:` trigger in `.pipelines/github-pr-validation.yml` only matched `aclmain`, so pull requests targeting release branches (e.g. `release/3.0`) got no validation build.

Add a `release/*` wildcard to the branch include list so PR validation runs for release branches too. Comment header updated to match.