### PR TITLE
rpm: map portage ignition to the ignition-flatcar RPM

### DIFF
--- a/build_library/rpm/package_catalog.yaml
+++ b/build_library/rpm/package_catalog.yaml
@@ -232,10 +232,14 @@ packages:
   app-admin/toolbox: SKIP
 
   # Flatcar-specific packages
-  app-admin/ignition: ignition
+  # NOTE: the RPM is named ignition-flatcar.  Azure Linux 3 has no package
+  # named "ignition" at all, so the historical mapping to "ignition" only
+  # worked because dnf5 silently resolved the spec to the single matching
+  # ignition-* package.  Name it explicitly.
+  app-admin/ignition: ignition-flatcar
   coreos-base/afterburn: afterburn
   coreos-base/flatcar-base: azurelinux-release
-  sys-apps/ignition: ignition
+  sys-apps/ignition: ignition-flatcar
 
   # Dependencies of oem-azure for Azure image building
   # oras is not sent through the catalog (used to pull sysexts)


### PR DESCRIPTION
## What

The package catalog maps `app-admin/ignition` and `sys-apps/ignition` to the RPM name `ignition`. Azure Linux 3 ships no package by that name — only `ignition-flatcar`. This maps them to the real package name.

## Why

Nothing in the AzL 3.0 repositories (`base`, `ms-oss`, `extended`, `cloud-native`, `ms-non-oss`) is named `ignition`, and nothing provides, obsoletes or requires that name. Checked all five repos' repodata directly.

The build works today only because dnf5 resolves the unmatched spec to the single available `ignition-*` package. Confirmed against a production build:

- `build_image` logs `Installing 149 RPM packages using dnf5: ... hwdata ignition inih ...` — the literal string `ignition` is what reaches the dnf5 command line.
- The resulting transaction table lists `ignition-flatcar x86_64 2.22.0-5 azurelinux-official-base` under the top-level `Installing:` header, not under `Installing dependencies:` — so dnf5 itself performed the substitution, silently and with no warning.

That is incidental behaviour rather than something the catalog should rely on. It hides the mistake, and it stops being correct on any release that ships a package literally named `ignition` — which would then be installed in place of the Flatcar fork.

## Risk

None. The same package is installed either way; this only makes the intent explicit.



---

Work item: [AB#22684](https://dev.azure.com/mariner-org/70814062-73d6-4295-8e5f-b224172b9c69/_workitems/edit/22684)
