### PR TITLE
rpm: skip five unused packages in the package catalog

### DIFF
--- a/build_library/rpm/package_catalog.yaml
+++ b/build_library/rpm/package_catalog.yaml
@@ -182,8 +182,10 @@ packages:
 
   # Version control
   dev-vcs/git: git
-  dev-vcs/mercurial: mercurial
-  dev-vcs/subversion: subversion
+  # mercurial and subversion are build-time only; they appear in no image
+  # or sysext package list.
+  dev-vcs/mercurial: SKIP
+  dev-vcs/subversion: SKIP
 
   # Debugging tools
   dev-debug/strace: strace
@@ -625,7 +627,9 @@ packages:
   dev-libs/mpdecimal: SKIP
   app-crypt/rhash: SKIP
   app-crypt/libb2: SKIP
-  dev-go/go-md2man: go-md2man
+  # go-md2man only generates man pages at build time; it is installed in no
+  # image or sysext.
+  dev-go/go-md2man: SKIP
 
   # Build tool alternatives (skip - build-time only)
   app-alternatives/lex: SKIP

--- a/build_library/rpm/package_catalog.yaml
+++ b/build_library/rpm/package_catalog.yaml
@@ -400,7 +400,12 @@ packages:
 
   # Additional Azure Linux packages - archives/compression
   app-arch/lz4: lz4
-  app-arch/ncompress: ncompress
+  # Legacy .Z (LZW) compress/uncompress. Pulled in as a direct RDEPEND of
+  # Flatcar's coreos-base/coreos image manifest, but nothing in the ACL
+  # image actually uses it: the only Azure Linux reverse dependency is
+  # perl-Archive-Extract-Z-uncompress in azurelinux-extended, which we do
+  # not ship.
+  app-arch/ncompress: SKIP
   app-arch/pigz: pigz
 
   # Container tools
@@ -422,7 +427,11 @@ packages:
   app-misc/jq: jq
 
   # Development libraries - C++
-  dev-cpp/gflags: gflags
+  # Only reaches the image through coreos-base/update_engine, which is
+  # already SKIPped (ACL does not ship update_engine). No other consumer:
+  # rocksdb and glog are the only Azure Linux reverse dependencies and
+  # neither is installed.
+  dev-cpp/gflags: SKIP
 
   # Development libraries - languages
   dev-lang/duktape: duktape


### PR DESCRIPTION
Two independent commits, safe to review (or drop) separately.

## 1. `mercurial`, `subversion`, `go-md2man` → `SKIP`

Pure catalog hygiene, **no functional change**. All three are mapped to RPM names but are installed in no image and no sysext:

- `mercurial` / `subversion` — VCS clients, build-time only
- `go-md2man` — generates man pages during package builds; reaches the SDK via `coreos-base/hard-host-depends`, never the image (it is already in `build_dev_binpkgs`'s default skip list)

Verified against the `packages.txt` artefacts of a production build (amd64 + arm64, base image and every sysext): none of the three appears in any of them.

## 2. `ncompress`, `gflags` → `SKIP`

**This one does change the base image** — both are installed today and neither is used.

**`ncompress`** (legacy `.Z` compress/uncompress) is a direct RDEPEND of `coreos-base/coreos-0.0.1.ebuild` (L101), which is how it reaches the image. Nothing in ACL invokes it. Its only Azure Linux reverse dependency is `perl-Archive-Extract-Z-uncompress` in `extended`, which we do not ship.

**`gflags`** reaches the image only via `coreos-base/update_engine-9999.ebuild` (L28-29) — and `coreos-base/update_engine` is already `SKIP` in this catalog, since ACL does not ship update_engine. Its only Azure Linux reverse dependencies are `rocksdb` and `glog`, neither of which is installed.

`git grep` confirms no other consumer of either name anywhere in the tree outside the portage manifests above.

## Context

Found while auditing which packages have no Azure Linux 4.0 equivalent — none of these five do. Rather than special-case them in a 4.0 overlay, they should not be in the image on 3.0 either.



---

Work item: [AB#22683](https://dev.azure.com/mariner-org/70814062-73d6-4295-8e5f-b224172b9c69/_workitems/edit/22683)
