### PR TITLE
sdk: enable xz RPM payload support in the SDK

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/package.use
@@ -34,3 +34,9 @@ app-emulation/qemu -pin-upstream-blobs
 
 # Enable systemd-boot and ukify in the SDK for UKI generation.
 sys-apps/systemd boot ukify
+
+# Azure Linux ships xz- (and bzip2-) compressed RPM payloads. rpm only
+# advertises the matching rpmlib(PayloadIs*) capabilities when built with the
+# lzma/bzip2 USE flags, which are off by default upstream. caps is required to
+# apply file capabilities from Azure Linux packages.
+app-arch/rpm caps lzma bzip2


### PR DESCRIPTION
Azure Linux 4 ships xz-compressed RPM payloads, which the SDK's `rpm` cannot install because it is built without the `lzma` USE flag (it never advertises `rpmlib(PayloadIsXz)`).

- Add `app-arch/rpm caps lzma bzip2` to the SDK target profile (`profiles/coreos/targets/sdk/package.use`).
- Putting it in the profile rather than in `Dockerfile.sdk-update` means it applies both when a fresh SDK image is bootstrapped and when an existing one is updated — the existing `--changed-use` emerge in `Dockerfile.sdk-update` picks up the rebuild.
- `bzip2` covers `rpmlib(PayloadIsBzip2)`; `caps` is pinned because file capabilities from Azure Linux packages depend on it.

---

Work item: [AB#22734](https://dev.azure.com/mariner-org/70814062-73d6-4295-8e5f-b224172b9c69/_workitems/edit/22734)
