### PR TITLE
Fix Azure VM provisioning fallback retries

### DIFF
--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -28,9 +28,10 @@ SECURE_BOOT_ENABLED=false
 AZ_ERROR_CODE=""
 AZ_ERROR_MESSAGE=""
 AZ_ERROR_TARGET=""
+TEST_BOOT_DIAGNOSTICS_STORAGE=$(get_boot_diagnostics_storage_name test-rg)
 
 az() {
-    if [[ " $* " != *" --boot-diagnostics-storage test-boot-diag "* ]]; then
+    if [[ " $* " != *" --boot-diagnostics-storage ${TEST_BOOT_DIAGNOSTICS_STORAGE} "* ]]; then
         printf 'missing create-time boot diagnostics storage argument\n' >&2
         return 2
     fi
@@ -58,7 +59,7 @@ assert_classification() {
     local rc=0
     local result
     result=$(_try_vm_create \
-        test-rg test-vm test-image test-sku test-region test-boot-diag 2>/dev/null) || rc=$?
+        test-rg test-vm test-image test-sku test-region 2>/dev/null) || rc=$?
 
     if [[ ${rc} -ne ${expected_rc} || "${result}" != "${expected_result}" ]]; then
         printf 'FAIL: %s returned rc=%s result=%q; expected rc=%s result=%q\n' \
@@ -158,11 +159,6 @@ assert_failed_vm_boot_diagnostics() {
         case "${1:-} ${2:-} ${3:-}" in
             "vm show -g")
                 printf 'vm:show\n' >> "${events_file}"
-                printf 'true\n'
-                return 0
-                ;;
-            "vm boot-diagnostics enable")
-                printf 'diagnostics:enable\n' >> "${events_file}"
                 return 0
                 ;;
             "vm boot-diagnostics get-boot-log")
@@ -550,9 +546,6 @@ assert_fallback_uses_clean_resource_group() {
             "network nic ip-config update")
                 return 0
                 ;;
-            "vm boot-diagnostics enable "*)
-                return 0
-                ;;
             *)
                 printf 'Unexpected az command: %q\n' "$*" >&2
                 return 1
@@ -658,7 +651,7 @@ assert_control_plane_failure_reuses_resource_group() {
                 fi
                 return 0
                 ;;
-            "network nic ip-config update"|"vm boot-diagnostics enable "*)
+            "network nic ip-config update")
                 return 0
                 ;;
             "group delete "*)
@@ -1008,7 +1001,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
                 fi
                 return 0
                 ;;
-            "network nic ip-config update"|"vm boot-diagnostics enable "*)
+            "network nic ip-config update")
                 return 0
                 ;;
             *)

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -61,8 +61,14 @@ assert_classification() {
 
     local rc=0
     local result
-    result=$(_try_vm_create \
-        test-rg test-vm test-image test-sku test-region 2>/dev/null) || rc=$?
+    if _try_vm_create \
+        test-rg test-vm test-image test-sku test-region \
+        >/dev/null 2>&1; then
+        rc=0
+    else
+        rc=$?
+    fi
+    result="$_VM_CREATE_RESULT"
 
     if [[ ${rc} -ne ${expected_rc} || "${result}" != "${expected_result}" ]]; then
         printf 'FAIL: %s returned rc=%s result=%q; expected rc=%s result=%q\n' \
@@ -86,18 +92,51 @@ assert_successful_vm_create_returns_cli_output() {
         printf '{"id":"test-vm"}\n'
     }
 
-    local result
-    if ! result=$(_try_vm_create \
-        test-rg test-vm test-image test-sku test-region 2>/dev/null); then
+    if ! _try_vm_create \
+        test-rg test-vm test-image test-sku test-region \
+        >/dev/null 2>&1; then
         printf 'FAIL: successful VM creation returned a failure\n' >&2
         return 1
     fi
+    local result="$_VM_CREATE_RESULT"
     if [[ "$result" != '{"id":"test-vm"}' ]]; then
         printf 'FAIL: successful VM creation returned %q\n' "$result" >&2
         return 1
     fi
 
     printf 'PASS: successful VM creation returns Azure CLI output\n'
+}
+
+assert_arm_warning_does_not_corrupt_vm_result() {
+    local log_file="${TEST_TMPDIR}/arm-security-warning"
+    warn() { printf 'WARN: %s\n' "$*"; }
+
+    BOARD=arm64-usr
+    SECURE_BOOT_ENABLED=false
+    AZ_ERROR_CODE=OSProvisioningTimedOut
+    AZ_ERROR_MESSAGE="OS provisioning for the VM did not finish in the allotted time."
+    AZ_ERROR_TARGET=""
+
+    local rc=0
+    if _try_vm_create \
+        test-rg test-vm test-image Standard_D2ps_v6 test-region \
+        >"$log_file" 2>/dev/null; then
+        rc=0
+    else
+        rc=$?
+    fi
+
+    if [[ $rc -ne 1 || "$_VM_CREATE_RESULT" != "PROVISIONING_TIMEOUT" ]]; then
+        printf 'FAIL: ARM warning corrupted VM result: rc=%s result=%q\n' \
+            "$rc" "$_VM_CREATE_RESULT" >&2
+        return 1
+    fi
+    if ! grep -qF 'Ignoring disabled Secure Boot setting' "$log_file"; then
+        printf 'FAIL: ARM security warning was not emitted\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: ARM security warnings do not corrupt VM classification\n'
 }
 
 assert_classification SkuNotAvailable \
@@ -129,6 +168,7 @@ assert_classification AuthorizationFailed \
     "The client is not authorized to create this VM." \
     2 ""
 ( assert_successful_vm_create_returns_cli_output )
+( assert_arm_warning_does_not_corrupt_vm_result )
 
 assert_vm_size_family_parsing() {
     local test_case vm_size expected actual
@@ -218,8 +258,9 @@ assert_failed_vm_boot_diagnostics() {
                 ;;
             "storage blob download")
                 printf 'storage:download\n' >> "${events_file}"
-                if [[ " $* " != *" --blob-url https://teststorage.blob.core.windows.net/bootdiagnostics-test/serialconsole.log?sig=test-secret "* ]]; then
-                    printf 'FAIL: boot diagnostics used the wrong serial log URI\n' >&2
+                if [[ " $* " != *" --blob-url https://teststorage.blob.core.windows.net/bootdiagnostics-test/serialconsole.log "* ]] ||
+                    [[ "${AZURE_STORAGE_SAS_TOKEN:-}" != "sig=test-secret" ]]; then
+                    printf 'FAIL: boot diagnostics did not separate the serial log URI and SAS token\n' >&2
                     return 1
                 fi
                 local destination=""
@@ -316,7 +357,7 @@ assert_provisioning_timeouts_are_bounded() {
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
         printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
-        echo "PROVISIONING_TIMEOUT"
+        _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         return 1
     }
 
@@ -356,7 +397,7 @@ assert_provisioning_timeouts_are_bounded() {
 
     BOARD=amd64-usr
     AZ_VM_SIZE=Standard_D2s_v5
-    AZ_BACKUP_VM_SIZES_AMD64="Standard_D2as_v5 Standard_F2s_v2 Standard_B2s_v2"
+    AZ_BACKUP_VM_SIZES_AMD64="Standard_D4s_v5 Standard_F2s_v2 Standard_B2s_v2"
     AZ_BACKUP_REGIONS=backup-region
     AZ_REGION=primary-region
     AZ_MAX_PROVISIONING_TIMEOUTS=2
@@ -371,7 +412,7 @@ assert_provisioning_timeouts_are_bounded() {
     fi
 
     local expected_attempts actual_attempts
-    expected_attempts=$'Standard_D2s_v5\nStandard_D2as_v5'
+    expected_attempts=$'Standard_D2s_v5\nStandard_F2s_v2'
     actual_attempts=$(cat "${attempts_file}")
     if [[ "${actual_attempts}" != "${expected_attempts}" ]]; then
         printf 'FAIL: provisioning timeout attempts were not bounded across distinct families\nExpected:\n%s\nActual:\n%s\n' \
@@ -390,7 +431,7 @@ assert_provisioning_timeouts_are_bounded() {
         return 1
     fi
 
-    printf 'PASS: provisioning timeouts stop after two distinct SKU families\n'
+    printf 'PASS: provisioning timeouts skip duplicate families and stop at the configured limit\n'
 }
 
 assert_single_provisioning_timeout_limit() {
@@ -405,7 +446,7 @@ assert_single_provisioning_timeout_limit() {
     capture_failed_vm_boot_diagnostics() { :; }
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
-        echo "PROVISIONING_TIMEOUT"
+        _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         return 1
     }
     az() {
@@ -450,7 +491,7 @@ assert_all_families_timeout_below_limit() {
     error() { printf '%s\n' "$*" >> "${errors_file}"; }
     capture_failed_vm_boot_diagnostics() { :; }
     _try_vm_create() {
-        echo "PROVISIONING_TIMEOUT"
+        _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         return 1
     }
     az() {
@@ -498,9 +539,9 @@ assert_mixed_failures_keep_generic_terminal_error() {
         attempt_count=$(wc -l < "${attempts_file}")
         printf '%s\n' "$4" >> "${attempts_file}"
         if [[ $attempt_count -eq 0 ]]; then
-            echo "PROVISIONING_TIMEOUT"
+            _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         else
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
         fi
         return 1
     }
@@ -561,7 +602,7 @@ assert_fallback_uses_clean_resource_group() {
         printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
 
         if [[ ${attempt_count} -eq 0 ]]; then
-            echo "PROVISIONING_TIMEOUT"
+            _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
             return 1
         fi
 
@@ -570,7 +611,7 @@ assert_fallback_uses_clean_resource_group() {
             return 2
         fi
 
-        echo '{"powerState":"VM running"}'
+        _VM_CREATE_RESULT='{"powerState":"VM running"}'
     }
 
     az() {
@@ -677,12 +718,12 @@ assert_control_plane_failure_reuses_resource_group() {
         printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
 
         if [[ ${attempt_count} -eq 0 ]]; then
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
 
         [[ "${vm_rg_name}" == "test-rg" ]] || return 2
-        echo '{"powerState":"VM running"}'
+        _VM_CREATE_RESULT='{"powerState":"VM running"}'
     }
 
     az() {
@@ -781,12 +822,12 @@ assert_control_plane_failure_with_vm_rotates_resource_group() {
         printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
 
         if [[ ${attempt_count} -eq 0 ]]; then
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
 
         [[ "${vm_rg_name}" == "test-rg-2" ]] || return 2
-        echo '{"powerState":"VM running"}'
+        _VM_CREATE_RESULT='{"powerState":"VM running"}'
     }
 
     az() {
@@ -877,7 +918,7 @@ assert_no_cleanup_preserves_timeout_resource_group() {
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
         printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
-        echo "PROVISIONING_TIMEOUT"
+        _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         return 1
     }
     az() {
@@ -900,6 +941,12 @@ assert_no_cleanup_preserves_timeout_resource_group() {
         esac
     }
 
+    get_vm_rg_name() {
+        local group_count
+        group_count=$(grep -c '^group:create:' "${events_file}" || true)
+        printf 'test-rg-%s\n' "$((group_count + 1))"
+    }
+
     BOARD=amd64-usr
     AZ_VM_SIZE=primary-sku
     AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
@@ -918,19 +965,19 @@ assert_no_cleanup_preserves_timeout_resource_group() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ndiagnostics:capture:test-rg-1'
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ndiagnostics:capture:test-rg-1\ngroup:create:test-rg-2\ncreate:fallback-sku@test-rg-2\ndiagnostics:capture:test-rg-2'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: --no-cleanup did not preserve the first failed resource group\nExpected:\n%s\nActual:\n%s\n' \
             "${expected_events}" "${actual_events}" >&2
         return 1
     fi
-    if [[ "$(wc -l < "${attempts_file}")" -ne 1 || "${VM_RG}" != "test-rg-1" ]]; then
-        printf 'FAIL: --no-cleanup continued fallback or lost resource-group ownership\n' >&2
+    if [[ "$(wc -l < "${attempts_file}")" -ne 2 || -n "${VM_RG}" ]]; then
+        printf 'FAIL: --no-cleanup did not continue through a fresh resource group\n' >&2
         return 1
     fi
 
-    printf 'PASS: --no-cleanup preserves the timed-out resource group\n'
+    printf 'PASS: --no-cleanup preserves timed-out resource groups and continues fallback\n'
 }
 
 assert_no_cleanup_preserves_resource_group_on_region_fallback() {
@@ -946,7 +993,7 @@ assert_no_cleanup_preserves_resource_group_on_region_fallback() {
     _try_vm_create() {
         printf '%s@%s\n' "$4" "$5" >> "${attempts_file}"
         printf 'create:%s@%s/%s\n' "$4" "$1" "$5" >> "${events_file}"
-        echo "RETRYABLE_VM_CREATE_ERROR"
+        _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
         return 1
     }
     az() {
@@ -973,6 +1020,8 @@ assert_no_cleanup_preserves_resource_group_on_region_fallback() {
         esac
     }
 
+    get_vm_rg_name() { echo "test-rg-2"; }
+
     BOARD=amd64-usr
     AZ_VM_SIZE=only-sku
     AZ_BACKUP_VM_SIZES_AMD64=""
@@ -990,19 +1039,19 @@ assert_no_cleanup_preserves_resource_group_on_region_fallback() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1/primary-region\nvm:list:test-rg-1'
+    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1/primary-region\nvm:list:test-rg-1\ngroup:create:test-rg-2\ncreate:only-sku@test-rg-2/backup-region\nvm:list:test-rg-2'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: --no-cleanup region fallback did not preserve the primary resource group\nExpected:\n%s\nActual:\n%s\n' \
             "${expected_events}" "${actual_events}" >&2
         return 1
     fi
-    if [[ "$(wc -l < "${attempts_file}")" -ne 1 || "${VM_RG}" != "test-rg-1" ]]; then
-        printf 'FAIL: --no-cleanup attempted the backup region or lost resource-group ownership\n' >&2
+    if [[ "$(wc -l < "${attempts_file}")" -ne 2 || "${VM_RG}" != "test-rg-2" ]]; then
+        printf 'FAIL: --no-cleanup did not continue into a fresh backup-region resource group\n' >&2
         return 1
     fi
 
-    printf 'PASS: --no-cleanup preserves the resource group across region fallback\n'
+    printf 'PASS: --no-cleanup preserves failed resource groups across region fallback\n'
 }
 
 assert_cleanup_failure_preserves_resource_group() {
@@ -1017,7 +1066,7 @@ assert_cleanup_failure_preserves_resource_group() {
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
         printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
-        echo "RETRYABLE_VM_CREATE_ERROR"
+        _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
         return 1
     }
     az() {
@@ -1133,7 +1182,7 @@ assert_resource_group_failure_stops_fallback() {
 
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
-        echo "PROVISIONING_TIMEOUT"
+        _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
         return 1
     }
 
@@ -1394,6 +1443,38 @@ assert_boot_diagnostics_storage_is_provisioned() {
     printf 'PASS: boot diagnostics storage is provisioned with each VM resource group\n'
 }
 
+assert_exhaustion_skips_cleanup_for_uncreated_resource_group() {
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+    _validate_arm_vm_size() { return 1; }
+    az() {
+        printf 'FAIL: exhaustion touched an uncreated resource group: %q\n' "$*" >&2
+        return 1
+    }
+
+    BOARD=arm64-usr
+    AZ_VM_SIZE=Standard_D2ps_v6
+    AZ_BACKUP_VM_SIZES_ARM64=""
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg
+
+    if create_vm_azure test-rg test-image-id >/dev/null; then
+        printf 'FAIL: exhaustion without eligible SKUs unexpectedly succeeded\n' >&2
+        return 1
+    fi
+    if [[ -n "$VM_RG" ]]; then
+        printf 'FAIL: exhaustion retained ownership of an uncreated resource group\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: exhaustion skips cleanup for an uncreated resource group\n'
+}
+
 assert_final_candidate_cleans_reused_resource_group() {
     local events_file="${TEST_TMPDIR}/final-candidate-events"
     : > "${events_file}"
@@ -1405,7 +1486,7 @@ assert_final_candidate_cleans_reused_resource_group() {
 
     _try_vm_create() {
         printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
-        echo "RETRYABLE_VM_CREATE_ERROR"
+        _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
         return 1
     }
 
@@ -1491,11 +1572,11 @@ assert_final_candidate_moves_directly_to_backup_region() {
         printf 'create:%s@%s/%s\n' "${vm_size}" "${vm_rg_name}" "${region}" >> "${events_file}"
 
         if [[ ${attempt_count} -eq 0 ]]; then
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
 
-        echo '{"powerState":"VM running"}'
+        _VM_CREATE_RESULT='{"powerState":"VM running"}'
     }
 
     az() {
@@ -1604,6 +1685,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
 ( assert_partial_resource_group_cleanup_failure_preserves_ownership )
 ( assert_no_cleanup_preserves_partial_resource_group )
 ( assert_boot_diagnostics_storage_is_provisioned )
+( assert_exhaustion_skips_cleanup_for_uncreated_resource_group )
 ( assert_final_candidate_cleans_reused_resource_group )
 ( assert_final_candidate_moves_directly_to_backup_region )
 )

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -69,7 +69,7 @@ assert_classification SkuNotAvailable \
     1 RETRYABLE_VM_CREATE_ERROR
 assert_classification OSProvisioningTimedOut \
     "OS provisioning for the VM did not finish in the allotted time." \
-    1 RETRYABLE_VM_CREATE_ERROR
+    1 PROVISIONING_TIMEOUT
 assert_classification AllocationFailed \
     "Allocation failed because the requested VM size is unavailable." \
     1 RETRYABLE_VM_CREATE_ERROR
@@ -93,6 +93,55 @@ assert_classification AuthorizationFailed \
     "The client is not authorized to create this VM." \
     2 ""
 
+assert_vm_size_family_parsing() {
+    local test_case vm_size expected actual
+    local cases=(
+        "Standard_D2s_v5:Ds_v5"
+        "Standard_D2as_v5:Das_v5"
+        "Standard_D2ads_v5:Dads_v5"
+        "Standard_D2ps_v6:Dps_v6"
+        "Standard_D2ps_v5:Dps_v5"
+        "Standard_F2s_v2:Fs_v2"
+        "custom-size:custom-size"
+    )
+
+    for test_case in "${cases[@]}"; do
+        vm_size="${test_case%%:*}"
+        expected="${test_case#*:}"
+        actual=$(get_vm_size_family "$vm_size")
+        if [[ "$actual" != "$expected" ]]; then
+            printf 'FAIL: family for %s was %s, expected %s\n' \
+                "$vm_size" "$actual" "$expected" >&2
+            return 1
+        fi
+    done
+
+    printf 'PASS: VM size families preserve modifiers and generations\n'
+}
+
+assert_timeout_configuration_validation() {
+    error() { :; }
+
+    local value
+    for value in 1 2 10; do
+        AZ_MAX_PROVISIONING_TIMEOUTS="$value"
+        if ! validate_azure_configuration; then
+            printf 'FAIL: valid timeout limit %s was rejected\n' "$value" >&2
+            return 1
+        fi
+    done
+
+    for value in 0 -1 abc ""; do
+        AZ_MAX_PROVISIONING_TIMEOUTS="$value"
+        if validate_azure_configuration; then
+            printf 'FAIL: invalid timeout limit %q was accepted\n' "$value" >&2
+            return 1
+        fi
+    done
+
+    printf 'PASS: provisioning timeout configuration is validated\n'
+}
+
 assert_failed_vm_boot_diagnostics() {
     local events_file="${TEST_TMPDIR}/boot-diagnostics-events"
     : > "${events_file}"
@@ -112,7 +161,17 @@ assert_failed_vm_boot_diagnostics() {
                 ;;
             "vm boot-diagnostics get-boot-log")
                 printf 'diagnostics:get-log\n' >> "${events_file}"
-                printf '"serial line one\\nserial line two\\n"\n'
+                if [[ " $* " != *" -o tsv "* ]]; then
+                    printf 'FAIL: boot diagnostics must request raw TSV output\n' >&2
+                    return 1
+                fi
+                local line
+                for line in $(seq 1 25); do
+                    printf 'warning line %s\n' "$line" >&2
+                done
+                for line in $(seq 1 205); do
+                    printf 'serial line %s\n' "$line"
+                done
                 return 0
                 ;;
             *)
@@ -134,8 +193,16 @@ assert_failed_vm_boot_diagnostics() {
             "${expected_events}" "${actual_events}" >&2
         return 1
     fi
-    if [[ "${serial_output}" != *"[serial] serial line two"* ]]; then
+    if ! grep -qFx '  [serial] serial line 205' <<< "$serial_output" || \
+        grep -qFx '  [serial] serial line 5' <<< "$serial_output" || \
+        ! grep -qFx '  [serial] serial line 6' <<< "$serial_output"; then
         printf 'FAIL: boot diagnostics serial output was not logged\n' >&2
+        return 1
+    fi
+    if ! grep -qFx '  [az] warning line 25' <<< "$serial_output" || \
+        grep -qFx '  [az] warning line 5' <<< "$serial_output" || \
+        ! grep -qFx '  [az] warning line 6' <<< "$serial_output"; then
+        printf 'FAIL: boot diagnostics stderr was not logged separately\n' >&2
         return 1
     fi
 
@@ -165,6 +232,244 @@ assert_failed_vm_boot_diagnostics() {
     fi
 
     printf 'PASS: failed VM boot diagnostics are captured best-effort\n'
+}
+
+assert_provisioning_timeouts_are_bounded() {
+    local events_file="${TEST_TMPDIR}/provisioning-timeout-events"
+    local attempts_file="${TEST_TMPDIR}/provisioning-timeout-attempts"
+    local errors_file="${TEST_TMPDIR}/provisioning-timeout-errors"
+    : > "${events_file}"
+    : > "${attempts_file}"
+    : > "${errors_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf '%s\n' "$*" >> "${errors_file}"; }
+    capture_failed_vm_boot_diagnostics() {
+        printf 'diagnostics:capture:%s\n' "$1" >> "${events_file}"
+    }
+
+    _try_vm_create() {
+        printf '%s\n' "$4" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
+        echo "PROVISIONING_TIMEOUT"
+        return 1
+    }
+
+    check_image_replicated_to_region() {
+        printf 'FAIL: timeout cap allowed a backup-region attempt\n' >&2
+        return 1
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                return 0
+                ;;
+            "group delete "*)
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    get_vm_rg_name() {
+        local group_count
+        group_count=$(grep -c '^group:create:' "${events_file}" || true)
+        printf 'test-rg-%s\n' "$((group_count + 1))"
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=Standard_D2s_v5
+    AZ_BACKUP_VM_SIZES_AMD64="Standard_D2as_v5 Standard_F2s_v2 Standard_B2s_v2"
+    AZ_BACKUP_REGIONS=backup-region
+    AZ_REGION=primary-region
+    AZ_MAX_PROVISIONING_TIMEOUTS=2
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: provisioning timeouts unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_attempts actual_attempts
+    expected_attempts=$'Standard_D2s_v5\nStandard_D2as_v5'
+    actual_attempts=$(cat "${attempts_file}")
+    if [[ "${actual_attempts}" != "${expected_attempts}" ]]; then
+        printf 'FAIL: provisioning timeout attempts were not bounded across distinct families\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_attempts}" "${actual_attempts}" >&2
+        return 1
+    fi
+    if ! grep -q 'likely image boot failure' "${errors_file}"; then
+        printf 'FAIL: provisioning timeout did not report a likely image boot failure\n' >&2
+        return 1
+    fi
+
+    local create_count
+    create_count=$(grep -c '^create:' "${events_file}")
+    if [[ ${create_count} -ne 2 ]]; then
+        printf 'FAIL: expected 2 VM attempts, got %s\n' "${create_count}" >&2
+        return 1
+    fi
+
+    printf 'PASS: provisioning timeouts stop after two distinct SKU families\n'
+}
+
+assert_single_provisioning_timeout_limit() {
+    local attempts_file="${TEST_TMPDIR}/single-timeout-attempts"
+    local errors_file="${TEST_TMPDIR}/single-timeout-errors"
+    : > "${attempts_file}"
+    : > "${errors_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf '%s\n' "$*" >> "${errors_file}"; }
+    capture_failed_vm_boot_diagnostics() { :; }
+    _try_vm_create() {
+        printf '%s\n' "$4" >> "${attempts_file}"
+        echo "PROVISIONING_TIMEOUT"
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-}" in
+            "group create"|"network public-ip"|"group delete") return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=Standard_D2s_v5
+    AZ_BACKUP_VM_SIZES_AMD64=Standard_F2s_v2
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=primary-region
+    AZ_MAX_PROVISIONING_TIMEOUTS=1
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+
+    if create_vm_azure test-rg test-image-id >/dev/null; then
+        printf 'FAIL: timeout limit 1 unexpectedly succeeded\n' >&2
+        return 1
+    fi
+    if [[ $(wc -l < "${attempts_file}") -ne 1 ]]; then
+        printf 'FAIL: timeout limit 1 allowed more than one attempt\n' >&2
+        return 1
+    fi
+    if ! grep -q 'likely image boot failure' "${errors_file}"; then
+        printf 'FAIL: timeout limit 1 did not report likely image boot failure\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: timeout limit 1 stops after the first provisioning timeout\n'
+}
+
+assert_all_families_timeout_below_limit() {
+    local errors_file="${TEST_TMPDIR}/all-families-timeout-errors"
+    : > "${errors_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf '%s\n' "$*" >> "${errors_file}"; }
+    capture_failed_vm_boot_diagnostics() { :; }
+    _try_vm_create() {
+        echo "PROVISIONING_TIMEOUT"
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-}" in
+            "group create"|"network public-ip"|"group delete") return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=Standard_D2s_v5
+    AZ_BACKUP_VM_SIZES_AMD64=""
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=primary-region
+    AZ_MAX_PROVISIONING_TIMEOUTS=2
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+
+    if create_vm_azure test-rg test-image-id >/dev/null; then
+        printf 'FAIL: all-family timeout unexpectedly succeeded\n' >&2
+        return 1
+    fi
+    if ! grep -q 'All configured VM SKU families timed out' "${errors_file}" || \
+        ! grep -q 'likely image boot failure' "${errors_file}"; then
+        printf 'FAIL: all-family timeout below cap was not identified as image boot failure\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: all-family timeout is identified even below the configured cap\n'
+}
+
+assert_mixed_failures_keep_generic_terminal_error() {
+    local attempts_file="${TEST_TMPDIR}/mixed-failure-attempts"
+    local errors_file="${TEST_TMPDIR}/mixed-failure-errors"
+    : > "${attempts_file}"
+    : > "${errors_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf '%s\n' "$*" >> "${errors_file}"; }
+    capture_failed_vm_boot_diagnostics() { :; }
+    _try_vm_create() {
+        local attempt_count
+        attempt_count=$(wc -l < "${attempts_file}")
+        printf '%s\n' "$4" >> "${attempts_file}"
+        if [[ $attempt_count -eq 0 ]]; then
+            echo "PROVISIONING_TIMEOUT"
+        else
+            echo "RETRYABLE_VM_CREATE_ERROR"
+        fi
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-}" in
+            "group create"|"network public-ip"|"group delete") return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    get_vm_rg_name() { printf 'mixed-rg-%s\n' "$(wc -l < "${attempts_file}")"; }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=Standard_D2s_v5
+    AZ_BACKUP_VM_SIZES_AMD64="Standard_F2s_v2 Standard_B2s_v2"
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=primary-region
+    AZ_MAX_PROVISIONING_TIMEOUTS=2
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+
+    if create_vm_azure mixed-rg-0 test-image-id >/dev/null; then
+        printf 'FAIL: mixed failures unexpectedly succeeded\n' >&2
+        return 1
+    fi
+    if grep -q 'likely image boot failure' "${errors_file}"; then
+        printf 'FAIL: mixed timeout/capacity failures were mislabeled as image boot failure\n' >&2
+        return 1
+    fi
+    if ! grep -q 'No VM candidate succeeded' "${errors_file}" || \
+        ! grep -q 'Provisioning timeouts:' "${errors_file}"; then
+        printf 'FAIL: mixed failures did not preserve generic exhaustion with timeout context\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: mixed timeout and capacity failures keep generic exhaustion signal\n'
 }
 
 assert_fallback_uses_clean_resource_group() {
@@ -563,10 +868,16 @@ assert_final_candidate_moves_directly_to_backup_region() {
     printf 'PASS: final candidate moves directly to a clean backup-region resource group\n'
 }
 
-assert_failed_vm_boot_diagnostics
-assert_fallback_uses_clean_resource_group
-assert_resource_group_failure_stops_fallback
-assert_public_ip_failure_cleans_resource_group
-assert_final_candidate_does_not_create_unused_resource_group
-assert_final_candidate_moves_directly_to_backup_region
+( assert_failed_vm_boot_diagnostics )
+( assert_vm_size_family_parsing )
+( assert_timeout_configuration_validation )
+( assert_provisioning_timeouts_are_bounded )
+( assert_single_provisioning_timeout_limit )
+( assert_all_families_timeout_below_limit )
+( assert_mixed_failures_keep_generic_terminal_error )
+( assert_fallback_uses_clean_resource_group )
+( assert_resource_group_failure_stops_fallback )
+( assert_public_ip_failure_cleans_resource_group )
+( assert_final_candidate_does_not_create_unused_resource_group )
+( assert_final_candidate_moves_directly_to_backup_region )
 )

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -1396,11 +1396,15 @@ assert_boot_diagnostics_storage_is_provisioned() {
 
     az() {
         case "${1:-} ${2:-} ${3:-} ${4:-}" in
-            "group create "*|"network public-ip create "*)
-                return 0
-                ;;
-            "storage account create "*)
-                printf '%s\n' "$*" >> "${events_file}"
+            "group create "*|"network public-ip create "*|"storage account create "*)
+                if [[ " $* " != *" --subscription test-subscription "* ]]; then
+                    printf 'FAIL: Azure resource creation omitted the configured subscription: %s\n' \
+                        "$*" >&2
+                    return 1
+                fi
+                if [[ "${1:-} ${2:-} ${3:-}" == "storage account create" ]]; then
+                    printf '%s\n' "$*" >> "${events_file}"
+                fi
                 return 0
                 ;;
             "group delete "*)
@@ -1429,6 +1433,7 @@ assert_boot_diagnostics_storage_is_provisioned() {
         return 1
     fi
     if [[ " $storage_command " != *" --name $storage_name "* ||
+        " $storage_command " != *" --subscription test-subscription "* ||
         " $storage_command " != *" --resource-group test-rg "* ||
         " $storage_command " != *" --location test-region "* ||
         " $storage_command " != *" --sku Standard_LRS "* ||
@@ -1440,7 +1445,7 @@ assert_boot_diagnostics_storage_is_provisioned() {
         return 1
     fi
 
-    printf 'PASS: boot diagnostics storage is provisioned with each VM resource group\n'
+    printf 'PASS: VM resources are provisioned in the configured subscription\n'
 }
 
 assert_exhaustion_skips_cleanup_for_uncreated_resource_group() {

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -30,6 +30,10 @@ AZ_ERROR_MESSAGE=""
 AZ_ERROR_TARGET=""
 
 az() {
+    if [[ " $* " != *" --boot-diagnostics-storage test-boot-diag "* ]]; then
+        printf 'missing create-time boot diagnostics storage argument\n' >&2
+        return 2
+    fi
     if [[ -n "${AZ_ERROR_TARGET}" ]]; then
         printf '{"error":{"code":"%s","message":"%s","target":"%s"}}\n' \
             "${AZ_ERROR_CODE}" "${AZ_ERROR_MESSAGE}" "${AZ_ERROR_TARGET}" >&2
@@ -53,7 +57,8 @@ assert_classification() {
 
     local rc=0
     local result
-    result=$(_try_vm_create test-rg test-vm test-image test-sku test-region 2>/dev/null) || rc=$?
+    result=$(_try_vm_create \
+        test-rg test-vm test-image test-sku test-region test-boot-diag 2>/dev/null) || rc=$?
 
     if [[ ${rc} -ne ${expected_rc} || "${result}" != "${expected_result}" ]]; then
         printf 'FAIL: %s returned rc=%s result=%q; expected rc=%s result=%q\n' \
@@ -153,6 +158,7 @@ assert_failed_vm_boot_diagnostics() {
         case "${1:-} ${2:-} ${3:-}" in
             "vm show -g")
                 printf 'vm:show\n' >> "${events_file}"
+                printf 'true\n'
                 return 0
                 ;;
             "vm boot-diagnostics enable")
@@ -186,7 +192,7 @@ assert_failed_vm_boot_diagnostics() {
         test-rg test-vm test-sku test-region 2>&1)
 
     local expected_events actual_events
-    expected_events=$'vm:show\ndiagnostics:enable\ndiagnostics:get-log'
+    expected_events=$'vm:show\ndiagnostics:get-log'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: boot diagnostics commands ran out of order\nExpected:\n%s\nActual:\n%s\n' \
@@ -270,6 +276,9 @@ assert_provisioning_timeouts_are_bounded() {
             "network public-ip create "*)
                 return 0
                 ;;
+            "storage account create "*)
+                return 0
+                ;;
             "group delete "*)
                 printf 'group:delete:%s\n' "$4" >> "${events_file}"
                 return 0
@@ -343,7 +352,7 @@ assert_single_provisioning_timeout_limit() {
     }
     az() {
         case "${1:-} ${2:-}" in
-            "group create"|"network public-ip"|"group delete") return 0 ;;
+            "group create"|"network public-ip"|"storage account"|"group delete") return 0 ;;
             *) return 1 ;;
         esac
     }
@@ -388,7 +397,7 @@ assert_all_families_timeout_below_limit() {
     }
     az() {
         case "${1:-} ${2:-}" in
-            "group create"|"network public-ip"|"group delete") return 0 ;;
+            "group create"|"network public-ip"|"storage account"|"group delete") return 0 ;;
             *) return 1 ;;
         esac
     }
@@ -439,7 +448,7 @@ assert_mixed_failures_keep_generic_terminal_error() {
     }
     az() {
         case "${1:-} ${2:-}" in
-            "group create"|"network public-ip"|"group delete") return 0 ;;
+            "group create"|"network public-ip"|"storage account"|"group delete"|"vm delete") return 0 ;;
             *) return 1 ;;
         esac
     }
@@ -494,7 +503,7 @@ assert_fallback_uses_clean_resource_group() {
         printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
 
         if [[ ${attempt_count} -eq 0 ]]; then
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            echo "PROVISIONING_TIMEOUT"
             return 1
         fi
 
@@ -513,6 +522,9 @@ assert_fallback_uses_clean_resource_group() {
                 return 0
                 ;;
             "network public-ip create "*)
+                return 0
+                ;;
+            "storage account create "*)
                 return 0
                 ;;
             "group delete "*)
@@ -587,6 +599,110 @@ assert_fallback_uses_clean_resource_group() {
     printf 'PASS: fallback isolates the next candidate in a clean resource group\n'
 }
 
+assert_control_plane_failure_reuses_resource_group() {
+    local events_file="${TEST_TMPDIR}/control-plane-retry-events"
+    local attempts_file="${TEST_TMPDIR}/control-plane-retry-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf 'ERROR: %s\n' "$*" >&2; }
+    capture_failed_vm_boot_diagnostics() {
+        printf 'FAIL: control-plane rejection attempted boot diagnostics\n' >&2
+        return 1
+    }
+
+    _try_vm_create() {
+        local vm_rg_name="$1"
+        local vm_size="$4"
+        local attempt_count
+        attempt_count=$(wc -l < "${attempts_file}")
+        printf '%s\n' "${vm_size}" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
+
+        if [[ ${attempt_count} -eq 0 ]]; then
+            echo "RETRYABLE_VM_CREATE_ERROR"
+            return 1
+        fi
+
+        [[ "${vm_rg_name}" == "test-rg" ]] || return 2
+        echo '{"powerState":"VM running"}'
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                return 0
+                ;;
+            "storage account create "*)
+                return 0
+                ;;
+            "vm delete -g "*)
+                printf 'vm:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm show "*)
+                echo "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/test-nic"
+                return 0
+                ;;
+            "network nic show "*)
+                if [[ "$*" == *"ipConfigurations[0].name"* ]]; then
+                    echo "test-ip-config"
+                else
+                    echo "test-nic"
+                fi
+                return 0
+                ;;
+            "network nic ip-config update"|"vm boot-diagnostics enable "*)
+                return 0
+                ;;
+            "group delete "*)
+                printf 'FAIL: control-plane rejection recycled its resource group\n' >&2
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg
+
+    if ! create_vm_azure test-rg test-image-id >/dev/null; then
+        printf 'FAIL: control-plane fallback did not reach the second candidate\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg\ncreate:primary-sku@test-rg\nvm:delete:test-rg\ncreate:fallback-sku@test-rg'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: control-plane fallback did not reuse its resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg" ]]; then
+        printf 'FAIL: control-plane fallback changed the owned resource group\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: control-plane fallback reuses its resource group\n'
+}
+
 assert_resource_group_failure_stops_fallback() {
     local attempts_file="${TEST_TMPDIR}/resource-group-failure-attempts"
     : > "${attempts_file}"
@@ -598,7 +714,7 @@ assert_resource_group_failure_stops_fallback() {
 
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
-        echo "RETRYABLE_VM_CREATE_ERROR"
+        echo "PROVISIONING_TIMEOUT"
         return 1
     }
 
@@ -607,7 +723,7 @@ assert_resource_group_failure_stops_fallback() {
             "group create "*)
                 [[ "$4" == "test-rg-1" ]]
                 ;;
-            "network public-ip create "*|"group delete "*)
+            "network public-ip create "*|"storage account create "*|"group delete "*)
                 return 0
                 ;;
             *)
@@ -695,6 +811,61 @@ assert_public_ip_failure_cleans_resource_group() {
     printf 'PASS: public-IP failure cleans up its partial resource group\n'
 }
 
+assert_boot_diagnostics_storage_is_provisioned() {
+    local events_file="${TEST_TMPDIR}/boot-diagnostics-storage-events"
+    : > "${events_file}"
+
+    info() { :; }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*|"network public-ip create "*)
+                return 0
+                ;;
+            "storage account create "*)
+                printf '%s\n' "$*" >> "${events_file}"
+                return 0
+                ;;
+            "group delete "*)
+                printf 'FAIL: successful diagnostics storage setup deleted its resource group\n' >&2
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    if ! create_vm_resource_group \
+        test-rg test-region test-public-ip createdBy=test purpose=VM-testing; then
+        printf 'FAIL: boot diagnostics storage setup failed\n' >&2
+        return 1
+    fi
+
+    local storage_name storage_command
+    storage_name=$(get_boot_diagnostics_storage_name test-rg)
+    storage_command=$(cat "${events_file}")
+    if ! [[ "$storage_name" =~ ^bootdiag[0-9a-f]{16}$ ]] || \
+        [[ ${#storage_name} -ne 24 ]]; then
+        printf 'FAIL: invalid boot diagnostics storage account name: %s\n' "$storage_name" >&2
+        return 1
+    fi
+    if [[ " $storage_command " != *" --name $storage_name "* ||
+        " $storage_command " != *" --resource-group test-rg "* ||
+        " $storage_command " != *" --location test-region "* ||
+        " $storage_command " != *" --sku Standard_LRS "* ||
+        " $storage_command " != *" --min-tls-version TLS1_2 "* ||
+        " $storage_command " != *" --allow-blob-public-access false "* ||
+        " $storage_command " != *" --tags createdBy=test purpose=VM-testing "* ]]; then
+        printf 'FAIL: boot diagnostics storage account is missing required configuration: %s\n' \
+            "$storage_command" >&2
+        return 1
+    fi
+
+    printf 'PASS: boot diagnostics storage is provisioned with each VM resource group\n'
+}
+
 assert_final_candidate_does_not_create_unused_resource_group() {
     local events_file="${TEST_TMPDIR}/final-candidate-events"
     : > "${events_file}"
@@ -717,6 +888,9 @@ assert_final_candidate_does_not_create_unused_resource_group() {
                 return 0
                 ;;
             "network public-ip create "*)
+                return 0
+                ;;
+            "storage account create "*)
                 return 0
                 ;;
             "group delete "*)
@@ -746,11 +920,15 @@ assert_final_candidate_does_not_create_unused_resource_group() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1\ngroup:delete:test-rg-1'
+    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: final candidate created an unused replacement resource group\nExpected:\n%s\nActual:\n%s\n' \
             "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg-1" ]]; then
+        printf 'FAIL: final control-plane failure lost the owned resource group\n' >&2
         return 1
     fi
 
@@ -807,8 +985,15 @@ assert_final_candidate_moves_directly_to_backup_region() {
             "network public-ip create "*)
                 return 0
                 ;;
+            "storage account create "*)
+                return 0
+                ;;
             "group delete "*)
                 printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm delete -g "*)
+                printf 'vm:delete:%s\n' "$4" >> "${events_file}"
                 return 0
                 ;;
             "vm show "*)
@@ -853,7 +1038,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1/primary-region\ncreate:only-sku@test-rg-1/primary-region\ngroup:delete:test-rg-1\ngroup:create:test-rg-2/backup-region\ncreate:only-sku@test-rg-2/backup-region'
+    expected_events=$'group:create:test-rg-1/primary-region\ncreate:only-sku@test-rg-1/primary-region\nvm:delete:test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2/backup-region\ncreate:only-sku@test-rg-2/backup-region'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: backup-region fallback created an intermediate resource group\nExpected:\n%s\nActual:\n%s\n' \
@@ -876,8 +1061,10 @@ assert_final_candidate_moves_directly_to_backup_region() {
 ( assert_all_families_timeout_below_limit )
 ( assert_mixed_failures_keep_generic_terminal_error )
 ( assert_fallback_uses_clean_resource_group )
+( assert_control_plane_failure_reuses_resource_group )
 ( assert_resource_group_failure_stops_fallback )
 ( assert_public_ip_failure_cleans_resource_group )
+( assert_boot_diagnostics_storage_is_provisioned )
 ( assert_final_candidate_does_not_create_unused_resource_group )
 ( assert_final_candidate_moves_directly_to_backup_region )
 )

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -3,9 +3,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+(
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TEST_TMPDIR}"' EXIT
 
 export AZ_SUB_ID=test-subscription
 export AZ_STORAGE_RG=test-storage-rg
@@ -24,10 +27,16 @@ SECURE_BOOT_ENABLED=false
 
 AZ_ERROR_CODE=""
 AZ_ERROR_MESSAGE=""
+AZ_ERROR_TARGET=""
 
 az() {
-    printf '{"error":{"code":"%s","message":"%s"}}\n' \
-        "${AZ_ERROR_CODE}" "${AZ_ERROR_MESSAGE}" >&2
+    if [[ -n "${AZ_ERROR_TARGET}" ]]; then
+        printf '{"error":{"code":"%s","message":"%s","target":"%s"}}\n' \
+            "${AZ_ERROR_CODE}" "${AZ_ERROR_MESSAGE}" "${AZ_ERROR_TARGET}" >&2
+    else
+        printf '{"error":{"code":"%s","message":"%s"}}\n' \
+            "${AZ_ERROR_CODE}" "${AZ_ERROR_MESSAGE}" >&2
+    fi
     return 1
 }
 
@@ -36,9 +45,11 @@ assert_classification() {
     local error_message="$2"
     local expected_rc="$3"
     local expected_result="$4"
+    local error_target="${5:-}"
 
     AZ_ERROR_CODE="${error_code}"
     AZ_ERROR_MESSAGE="${error_message}"
+    AZ_ERROR_TARGET="${error_target}"
 
     local rc=0
     local result
@@ -65,6 +76,13 @@ assert_classification AllocationFailed \
 assert_classification ZonalAllocationFailed \
     "Allocation failed in the requested zone." \
     1 RETRYABLE_VM_CREATE_ERROR
+assert_classification InvalidParameter \
+    "The selected VM size is incompatible with the image." \
+    1 RETRYABLE_VM_CREATE_ERROR \
+    vmSize
+assert_classification TrustedLaunchNotSupported \
+    "The selected VM size does not support TrustedLaunch." \
+    1 RETRYABLE_VM_CREATE_ERROR
 assert_classification OperationNotAllowed \
     "The operation would exceed the approved regional quota." \
     1 RETRYABLE_VM_CREATE_ERROR
@@ -74,3 +92,400 @@ assert_classification OperationNotAllowed \
 assert_classification AuthorizationFailed \
     "The client is not authorized to create this VM." \
     2 ""
+
+assert_fallback_uses_clean_resource_group() {
+    local events_file="${TEST_TMPDIR}/fallback-events"
+    local attempts_file="${TEST_TMPDIR}/fallback-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf 'ERROR: %s\n' "$*" >&2; }
+
+    _try_vm_create() {
+        local vm_rg_name="$1"
+        local vm_size="$4"
+        local attempt_count
+        attempt_count=$(wc -l < "${attempts_file}")
+        printf '%s\n' "${vm_size}" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
+
+        if [[ ${attempt_count} -eq 0 ]]; then
+            echo "RETRYABLE_VM_CREATE_ERROR"
+            return 1
+        fi
+
+        if [[ "${vm_rg_name}" == "test-rg-1" ]]; then
+            echo "The retry reused the failed resource group." >&2
+            return 2
+        fi
+
+        echo '{"powerState":"VM running"}'
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                return 0
+                ;;
+            "group delete "*)
+                if [[ " $* " != *" --no-wait "* ]]; then
+                    printf 'FAIL: failed resource-group deletion must be asynchronous\n' >&2
+                    return 1
+                fi
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm show "*)
+                echo "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/test-nic"
+                return 0
+                ;;
+            "network nic show "*)
+                if [[ "$*" == *"ipConfigurations[0].name"* ]]; then
+                    echo "test-ip-config"
+                else
+                    echo "test-nic"
+                fi
+                return 0
+                ;;
+            "network nic ip-config update")
+                return 0
+                ;;
+            "vm boot-diagnostics enable "*)
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    get_vm_rg_name() {
+        echo "test-rg-2"
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if ! create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: fallback did not reach the second candidate in a clean resource group\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2\ncreate:fallback-sku@test-rg-2'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: unexpected fallback order\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${AZ_VM_SIZE}" != "fallback-sku" ]]; then
+        printf 'FAIL: successful fallback SKU was not retained\n' >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg-2" ]]; then
+        printf 'FAIL: successful fallback resource group was not retained\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: fallback isolates the next candidate in a clean resource group\n'
+}
+
+assert_resource_group_failure_stops_fallback() {
+    local attempts_file="${TEST_TMPDIR}/resource-group-failure-attempts"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+
+    _try_vm_create() {
+        printf '%s\n' "$4" >> "${attempts_file}"
+        echo "RETRYABLE_VM_CREATE_ERROR"
+        return 1
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                [[ "$4" == "test-rg-1" ]]
+                ;;
+            "network public-ip create "*|"group delete "*)
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    get_vm_rg_name() {
+        echo "test-rg-2"
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: fallback continued without a clean resource group\n' >&2
+        return 1
+    fi
+
+    local attempt_count
+    attempt_count=$(wc -l < "${attempts_file}")
+    if [[ ${attempt_count} -ne 1 ]]; then
+        printf 'FAIL: resource-group setup failure allowed %s VM creation attempts\n' "${attempt_count}" >&2
+        return 1
+    fi
+
+    printf 'PASS: failed resource-group setup stops fallback before candidate reuse\n'
+}
+
+assert_public_ip_failure_cleans_resource_group() {
+    local events_file="${TEST_TMPDIR}/public-ip-failure-events"
+    : > "${events_file}"
+
+    info() { :; }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                printf 'public-ip:create:failed\n' >> "${events_file}"
+                return 1
+                ;;
+            "group delete "*)
+                if [[ " $* " != *" --no-wait "* ]]; then
+                    printf 'FAIL: partial resource-group deletion must be asynchronous\n' >&2
+                    return 1
+                fi
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    if create_vm_resource_group \
+        test-rg test-region test-public-ip createdBy=test; then
+        printf 'FAIL: public-IP failure unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg\npublic-ip:create:failed\ngroup:delete:test-rg'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: public-IP failure did not clean up its partial resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+
+    printf 'PASS: public-IP failure cleans up its partial resource group\n'
+}
+
+assert_final_candidate_does_not_create_unused_resource_group() {
+    local events_file="${TEST_TMPDIR}/final-candidate-events"
+    : > "${events_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+
+    _try_vm_create() {
+        printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
+        echo "RETRYABLE_VM_CREATE_ERROR"
+        return 1
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                return 0
+                ;;
+            "group delete "*)
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=only-sku
+    AZ_BACKUP_VM_SIZES_AMD64=""
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: final retryable candidate unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1\ngroup:delete:test-rg-1'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: final candidate created an unused replacement resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+
+    printf 'PASS: final candidate does not create an unused resource group\n'
+}
+
+assert_final_candidate_moves_directly_to_backup_region() {
+    local events_file="${TEST_TMPDIR}/backup-region-events"
+    local attempts_file="${TEST_TMPDIR}/backup-region-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf 'ERROR: %s\n' "$*" >&2; }
+
+    check_image_replicated_to_region() {
+        [[ "$2" == "backup-region" ]]
+    }
+
+    _try_vm_create() {
+        local vm_rg_name="$1"
+        local vm_size="$4"
+        local region="$5"
+        local attempt_count
+        attempt_count=$(wc -l < "${attempts_file}")
+        printf '%s\n' "${vm_size}" >> "${attempts_file}"
+        printf 'create:%s@%s/%s\n' "${vm_size}" "${vm_rg_name}" "${region}" >> "${events_file}"
+
+        if [[ ${attempt_count} -eq 0 ]]; then
+            echo "RETRYABLE_VM_CREATE_ERROR"
+            return 1
+        fi
+
+        echo '{"powerState":"VM running"}'
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                local region=""
+                local previous=""
+                for argument in "$@"; do
+                    if [[ "${previous}" == "--location" ]]; then
+                        region="${argument}"
+                        break
+                    fi
+                    previous="${argument}"
+                done
+                printf 'group:create:%s/%s\n' "$4" "${region}" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                return 0
+                ;;
+            "group delete "*)
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm show "*)
+                echo "/subscriptions/test/resourceGroups/test-rg-2/providers/Microsoft.Network/networkInterfaces/test-nic"
+                return 0
+                ;;
+            "network nic show "*)
+                if [[ "$*" == *"ipConfigurations[0].name"* ]]; then
+                    echo "test-ip-config"
+                else
+                    echo "test-nic"
+                fi
+                return 0
+                ;;
+            "network nic ip-config update"|"vm boot-diagnostics enable "*)
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    get_vm_rg_name() {
+        echo "test-rg-2"
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=only-sku
+    AZ_BACKUP_VM_SIZES_AMD64=""
+    AZ_BACKUP_REGIONS=backup-region
+    AZ_REGION=primary-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if ! create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: final candidate did not advance directly to the backup region\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1/primary-region\ncreate:only-sku@test-rg-1/primary-region\ngroup:delete:test-rg-1\ngroup:create:test-rg-2/backup-region\ncreate:only-sku@test-rg-2/backup-region'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: backup-region fallback created an intermediate resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${AZ_REGION}" != "backup-region" || "${VM_RG}" != "test-rg-2" ]]; then
+        printf 'FAIL: backup-region fallback state was not retained\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: final candidate moves directly to a clean backup-region resource group\n'
+}
+
+assert_fallback_uses_clean_resource_group
+assert_resource_group_failure_stops_fallback
+assert_public_ip_failure_cleans_resource_group
+assert_final_candidate_does_not_create_unused_resource_group
+assert_final_candidate_moves_directly_to_backup_region
+)

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export AZ_SUB_ID=test-subscription
+export AZ_STORAGE_RG=test-storage-rg
+export AZ_STORAGE_ACC=teststorage
+export AZ_STORAGE_CONTAINER=test-container
+export AZ_GALLERY_RG=test-gallery-rg
+export AZ_ACG=test-gallery
+
+# shellcheck source=acl/validate/validate_azure.sh
+unset _VALIDATE_AZURE_LOADED
+source "${SCRIPT_DIR}/validate_azure.sh"
+
+VM_SSH_USER=tester
+VM_SSH_KEY="${TMPDIR:-/tmp}/test-key"
+SECURE_BOOT_ENABLED=false
+
+AZ_ERROR_CODE=""
+AZ_ERROR_MESSAGE=""
+
+az() {
+    printf '{"error":{"code":"%s","message":"%s"}}\n' \
+        "${AZ_ERROR_CODE}" "${AZ_ERROR_MESSAGE}" >&2
+    return 1
+}
+
+assert_classification() {
+    local error_code="$1"
+    local error_message="$2"
+    local expected_rc="$3"
+    local expected_result="$4"
+
+    AZ_ERROR_CODE="${error_code}"
+    AZ_ERROR_MESSAGE="${error_message}"
+
+    local rc=0
+    local result
+    result=$(_try_vm_create test-rg test-vm test-image test-sku test-region 2>/dev/null) || rc=$?
+
+    if [[ ${rc} -ne ${expected_rc} || "${result}" != "${expected_result}" ]]; then
+        printf 'FAIL: %s returned rc=%s result=%q; expected rc=%s result=%q\n' \
+            "${error_code}" "${rc}" "${result}" "${expected_rc}" "${expected_result}" >&2
+        return 1
+    fi
+
+    printf 'PASS: %s\n' "${error_code}"
+}
+
+assert_classification SkuNotAvailable \
+    "The requested VM size is not available in this location." \
+    1 RETRYABLE_VM_CREATE_ERROR
+assert_classification OSProvisioningTimedOut \
+    "OS provisioning for the VM did not finish in the allotted time." \
+    1 RETRYABLE_VM_CREATE_ERROR
+assert_classification AllocationFailed \
+    "Allocation failed because the requested VM size is unavailable." \
+    1 RETRYABLE_VM_CREATE_ERROR
+assert_classification ZonalAllocationFailed \
+    "Allocation failed in the requested zone." \
+    1 RETRYABLE_VM_CREATE_ERROR
+assert_classification OperationNotAllowed \
+    "The operation would exceed the approved regional quota." \
+    1 RETRYABLE_VM_CREATE_ERROR
+assert_classification OperationNotAllowed \
+    "The subscription is not registered for this feature." \
+    2 ""
+assert_classification AuthorizationFailed \
+    "The client is not authorized to create this VM." \
+    2 ""

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -1098,6 +1098,30 @@ assert_cleanup_uses_configured_subscription() {
     printf 'PASS: failed VM cleanup uses the configured subscription\n'
 }
 
+assert_cleanup_failure_logs_azure_error() {
+    local warnings_file="${TEST_TMPDIR}/cleanup-error-warnings"
+    : > "$warnings_file"
+
+    info() { :; }
+    warn() { printf '%s\n' "$*" >> "$warnings_file"; }
+    az() {
+        printf 'AuthorizationFailed: cleanup denied\n' >&2
+        return 1
+    }
+
+    NO_CLEANUP=false
+    if schedule_failed_vm_rg_cleanup test-rg "test failure"; then
+        printf 'FAIL: failed cleanup was reported as scheduled\n' >&2
+        return 1
+    fi
+    if ! grep -qF 'az error: AuthorizationFailed: cleanup denied' "$warnings_file"; then
+        printf 'FAIL: Azure cleanup error was not logged\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: failed VM cleanup logs the Azure CLI error\n'
+}
+
 assert_resource_group_failure_stops_fallback() {
     local attempts_file="${TEST_TMPDIR}/resource-group-failure-attempts"
     : > "${attempts_file}"
@@ -1574,6 +1598,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
 ( assert_no_cleanup_preserves_resource_group_on_region_fallback )
 ( assert_cleanup_failure_preserves_resource_group )
 ( assert_cleanup_uses_configured_subscription )
+( assert_cleanup_failure_logs_azure_error )
 ( assert_resource_group_failure_stops_fallback )
 ( assert_public_ip_failure_cleans_resource_group )
 ( assert_partial_resource_group_cleanup_failure_preserves_ownership )

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -1077,6 +1077,27 @@ assert_cleanup_failure_preserves_resource_group() {
     printf 'PASS: cleanup failure preserves resource-group ownership\n'
 }
 
+assert_cleanup_uses_configured_subscription() {
+    info() { :; }
+    warn() { :; }
+
+    az() {
+        local expected="group delete -n test-rg --subscription test-subscription -y --no-wait"
+        if [[ "$*" != "$expected" ]]; then
+            printf 'FAIL: cleanup command was %q; expected %q\n' "$*" "$expected" >&2
+            return 1
+        fi
+    }
+
+    NO_CLEANUP=false
+    if ! schedule_failed_vm_rg_cleanup test-rg "test failure"; then
+        printf 'FAIL: subscription-scoped cleanup was not scheduled\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: failed VM cleanup uses the configured subscription\n'
+}
+
 assert_resource_group_failure_stops_fallback() {
     local attempts_file="${TEST_TMPDIR}/resource-group-failure-attempts"
     : > "${attempts_file}"
@@ -1349,7 +1370,7 @@ assert_boot_diagnostics_storage_is_provisioned() {
     printf 'PASS: boot diagnostics storage is provisioned with each VM resource group\n'
 }
 
-assert_final_candidate_does_not_create_unused_resource_group() {
+assert_final_candidate_cleans_reused_resource_group() {
     local events_file="${TEST_TMPDIR}/final-candidate-events"
     : > "${events_file}"
 
@@ -1406,19 +1427,19 @@ assert_final_candidate_does_not_create_unused_resource_group() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1'
+    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1\ngroup:delete:test-rg-1'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
-        printf 'FAIL: final candidate created an unused replacement resource group\nExpected:\n%s\nActual:\n%s\n' \
+        printf 'FAIL: final candidate did not clean its reused resource group\nExpected:\n%s\nActual:\n%s\n' \
             "${expected_events}" "${actual_events}" >&2
         return 1
     fi
-    if [[ "${VM_RG}" != "test-rg-1" ]]; then
-        printf 'FAIL: final control-plane failure lost the owned resource group\n' >&2
+    if [[ -n "${VM_RG}" ]]; then
+        printf 'FAIL: final control-plane cleanup retained resource-group ownership\n' >&2
         return 1
     fi
 
-    printf 'PASS: final candidate does not create an unused resource group\n'
+    printf 'PASS: final candidate cleans its reused resource group\n'
 }
 
 assert_final_candidate_moves_directly_to_backup_region() {
@@ -1552,11 +1573,12 @@ assert_final_candidate_moves_directly_to_backup_region() {
 ( assert_no_cleanup_preserves_timeout_resource_group )
 ( assert_no_cleanup_preserves_resource_group_on_region_fallback )
 ( assert_cleanup_failure_preserves_resource_group )
+( assert_cleanup_uses_configured_subscription )
 ( assert_resource_group_failure_stops_fallback )
 ( assert_public_ip_failure_cleans_resource_group )
 ( assert_partial_resource_group_cleanup_failure_preserves_ownership )
 ( assert_no_cleanup_preserves_partial_resource_group )
 ( assert_boot_diagnostics_storage_is_provisioned )
-( assert_final_candidate_does_not_create_unused_resource_group )
+( assert_final_candidate_cleans_reused_resource_group )
 ( assert_final_candidate_moves_directly_to_backup_region )
 )

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -2,6 +2,9 @@
 
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Regression tests for Azure VM provisioning fallback, diagnostics, and cleanup.
+# The suite mocks Azure CLI calls so validation behavior can be tested locally.
 
 (
 set -euo pipefail
@@ -70,6 +73,33 @@ assert_classification() {
     printf 'PASS: %s\n' "${error_code}"
 }
 
+assert_successful_vm_create_returns_cli_output() {
+    az() {
+        if [[ "$*" != "vm create "* ]]; then
+            printf 'unexpected Azure CLI command: %s\n' "$*" >&2
+            return 1
+        fi
+        if [[ " $* " != *" --boot-diagnostics-storage ${TEST_BOOT_DIAGNOSTICS_STORAGE} "* ]]; then
+            printf 'missing create-time boot diagnostics storage argument\n' >&2
+            return 1
+        fi
+        printf '{"id":"test-vm"}\n'
+    }
+
+    local result
+    if ! result=$(_try_vm_create \
+        test-rg test-vm test-image test-sku test-region 2>/dev/null); then
+        printf 'FAIL: successful VM creation returned a failure\n' >&2
+        return 1
+    fi
+    if [[ "$result" != '{"id":"test-vm"}' ]]; then
+        printf 'FAIL: successful VM creation returned %q\n' "$result" >&2
+        return 1
+    fi
+
+    printf 'PASS: successful VM creation returns Azure CLI output\n'
+}
+
 assert_classification SkuNotAvailable \
     "The requested VM size is not available in this location." \
     1 RETRYABLE_VM_CREATE_ERROR
@@ -98,6 +128,7 @@ assert_classification OperationNotAllowed \
 assert_classification AuthorizationFailed \
     "The client is not authorized to create this VM." \
     2 ""
+( assert_successful_vm_create_returns_cli_output )
 
 assert_vm_size_family_parsing() {
     local test_case vm_size expected actual

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -93,6 +93,80 @@ assert_classification AuthorizationFailed \
     "The client is not authorized to create this VM." \
     2 ""
 
+assert_failed_vm_boot_diagnostics() {
+    local events_file="${TEST_TMPDIR}/boot-diagnostics-events"
+    : > "${events_file}"
+
+    info() { :; }
+    warn() { :; }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-}" in
+            "vm show -g")
+                printf 'vm:show\n' >> "${events_file}"
+                return 0
+                ;;
+            "vm boot-diagnostics enable")
+                printf 'diagnostics:enable\n' >> "${events_file}"
+                return 0
+                ;;
+            "vm boot-diagnostics get-boot-log")
+                printf 'diagnostics:get-log\n' >> "${events_file}"
+                printf '"serial line one\\nserial line two\\n"\n'
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    local serial_output
+    serial_output=$(capture_failed_vm_boot_diagnostics \
+        test-rg test-vm test-sku test-region 2>&1)
+
+    local expected_events actual_events
+    expected_events=$'vm:show\ndiagnostics:enable\ndiagnostics:get-log'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: boot diagnostics commands ran out of order\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${serial_output}" != *"[serial] serial line two"* ]]; then
+        printf 'FAIL: boot diagnostics serial output was not logged\n' >&2
+        return 1
+    fi
+
+    : > "${events_file}"
+    az() {
+        case "${1:-} ${2:-} ${3:-}" in
+            "vm show -g")
+                printf 'vm:show\n' >> "${events_file}"
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command after missing VM: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    if ! capture_failed_vm_boot_diagnostics \
+        test-rg test-vm test-sku test-region >/dev/null; then
+        printf 'FAIL: missing VM resource made diagnostics fatal\n' >&2
+        return 1
+    fi
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "vm:show" ]]; then
+        printf 'FAIL: missing VM resource still attempted boot diagnostics\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: failed VM boot diagnostics are captured best-effort\n'
+}
+
 assert_fallback_uses_clean_resource_group() {
     local events_file="${TEST_TMPDIR}/fallback-events"
     local attempts_file="${TEST_TMPDIR}/fallback-attempts"
@@ -102,6 +176,9 @@ assert_fallback_uses_clean_resource_group() {
     info() { :; }
     warn() { :; }
     error() { printf 'ERROR: %s\n' "$*" >&2; }
+    capture_failed_vm_boot_diagnostics() {
+        printf 'diagnostics:capture:%s\n' "$1" >> "${events_file}"
+    }
 
     _try_vm_create() {
         local vm_rg_name="$1"
@@ -186,7 +263,7 @@ assert_fallback_uses_clean_resource_group() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2\ncreate:fallback-sku@test-rg-2'
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ndiagnostics:capture:test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2\ncreate:fallback-sku@test-rg-2'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: unexpected fallback order\nExpected:\n%s\nActual:\n%s\n' \
@@ -212,6 +289,7 @@ assert_resource_group_failure_stops_fallback() {
     info() { :; }
     warn() { :; }
     error() { :; }
+    capture_failed_vm_boot_diagnostics() { :; }
 
     _try_vm_create() {
         printf '%s\n' "$4" >> "${attempts_file}"
@@ -319,6 +397,7 @@ assert_final_candidate_does_not_create_unused_resource_group() {
     info() { :; }
     warn() { :; }
     error() { :; }
+    capture_failed_vm_boot_diagnostics() { :; }
 
     _try_vm_create() {
         printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
@@ -382,6 +461,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
     info() { :; }
     warn() { :; }
     error() { printf 'ERROR: %s\n' "$*" >&2; }
+    capture_failed_vm_boot_diagnostics() { :; }
 
     check_image_replicated_to_region() {
         [[ "$2" == "backup-region" ]]
@@ -483,6 +563,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
     printf 'PASS: final candidate moves directly to a clean backup-region resource group\n'
 }
 
+assert_failed_vm_boot_diagnostics
 assert_fallback_uses_clean_resource_group
 assert_resource_group_failure_stops_fallback
 assert_public_ip_failure_cleans_resource_group

--- a/acl/validate/test_validate_azure.sh
+++ b/acl/validate/test_validate_azure.sh
@@ -125,6 +125,21 @@ assert_vm_size_family_parsing() {
     printf 'PASS: VM size families preserve modifiers and generations\n'
 }
 
+assert_resource_group_name_generation() {
+    local name
+    VM_RG_PREFIX=test-prefix
+    if ! name=$(get_vm_rg_name); then
+        printf 'FAIL: resource-group name generation failed under pipefail\n' >&2
+        return 1
+    fi
+    if ! [[ "$name" =~ ^test-prefix-[0-9a-f]{8}$ ]]; then
+        printf 'FAIL: invalid generated resource-group name: %s\n' "$name" >&2
+        return 1
+    fi
+
+    printf 'PASS: resource-group name generation is pipefail-safe\n'
+}
+
 assert_timeout_configuration_validation() {
     error() { :; }
 
@@ -161,18 +176,36 @@ assert_failed_vm_boot_diagnostics() {
                 printf 'vm:show\n' >> "${events_file}"
                 return 0
                 ;;
-            "vm boot-diagnostics get-boot-log")
-                printf 'diagnostics:get-log\n' >> "${events_file}"
-                if [[ " $* " != *" -o tsv "* ]]; then
-                    printf 'FAIL: boot diagnostics must request raw TSV output\n' >&2
+            "vm boot-diagnostics get-boot-log-uris")
+                printf 'diagnostics:get-uris\n' >> "${events_file}"
+                if [[ " $* " != *" --query serialConsoleLogBlobUri "* ]]; then
+                    printf 'FAIL: boot diagnostics must request the serial log URI\n' >&2
+                    return 1
+                fi
+                printf 'https://teststorage.blob.core.windows.net/bootdiagnostics-test/serialconsole.log?sig=test-secret\n'
+                return 0
+                ;;
+            "storage blob download")
+                printf 'storage:download\n' >> "${events_file}"
+                if [[ " $* " != *" --blob-url https://teststorage.blob.core.windows.net/bootdiagnostics-test/serialconsole.log?sig=test-secret "* ]]; then
+                    printf 'FAIL: boot diagnostics used the wrong serial log URI\n' >&2
+                    return 1
+                fi
+                local destination=""
+                while [[ $# -gt 0 ]]; do
+                    if [[ "$1" == "--file" ]]; then
+                        destination="$2"
+                        break
+                    fi
+                    shift
+                done
+                if [[ -z "$destination" ]]; then
+                    printf 'FAIL: boot diagnostics download has no destination\n' >&2
                     return 1
                 fi
                 local line
-                for line in $(seq 1 25); do
-                    printf 'warning line %s\n' "$line" >&2
-                done
                 for line in $(seq 1 205); do
-                    printf 'serial line %s\n' "$line"
+                    printf 'serial line %s\n' "$line" >> "$destination"
                 done
                 return 0
                 ;;
@@ -188,7 +221,7 @@ assert_failed_vm_boot_diagnostics() {
         test-rg test-vm test-sku test-region 2>&1)
 
     local expected_events actual_events
-    expected_events=$'vm:show\ndiagnostics:get-log'
+    expected_events=$'vm:show\ndiagnostics:get-uris\nstorage:download'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: boot diagnostics commands ran out of order\nExpected:\n%s\nActual:\n%s\n' \
@@ -201,10 +234,8 @@ assert_failed_vm_boot_diagnostics() {
         printf 'FAIL: boot diagnostics serial output was not logged\n' >&2
         return 1
     fi
-    if ! grep -qFx '  [az] warning line 25' <<< "$serial_output" || \
-        grep -qFx '  [az] warning line 5' <<< "$serial_output" || \
-        ! grep -qFx '  [az] warning line 6' <<< "$serial_output"; then
-        printf 'FAIL: boot diagnostics stderr was not logged separately\n' >&2
+    if grep -q 'test-secret' <<< "$serial_output"; then
+        printf 'FAIL: boot diagnostics exposed the SAS URI\n' >&2
         return 1
     fi
 
@@ -635,8 +666,8 @@ assert_control_plane_failure_reuses_resource_group() {
             "storage account create "*)
                 return 0
                 ;;
-            "vm delete -g "*)
-                printf 'vm:delete:%s\n' "$4" >> "${events_file}"
+            "vm list --resource-group "*)
+                printf 'vm:list:%s\n' "$4" >> "${events_file}"
                 return 0
                 ;;
             "vm show "*)
@@ -681,7 +712,7 @@ assert_control_plane_failure_reuses_resource_group() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg\ncreate:primary-sku@test-rg\nvm:delete:test-rg\ncreate:fallback-sku@test-rg'
+    expected_events=$'group:create:test-rg\ncreate:primary-sku@test-rg\nvm:list:test-rg\ncreate:fallback-sku@test-rg'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: control-plane fallback did not reuse its resource group\nExpected:\n%s\nActual:\n%s\n' \
@@ -694,6 +725,325 @@ assert_control_plane_failure_reuses_resource_group() {
     fi
 
     printf 'PASS: control-plane fallback reuses its resource group\n'
+}
+
+assert_control_plane_failure_with_vm_rotates_resource_group() {
+    local events_file="${TEST_TMPDIR}/control-plane-vm-events"
+    local attempts_file="${TEST_TMPDIR}/control-plane-vm-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { printf 'ERROR: %s\n' "$*" >&2; }
+    capture_failed_vm_boot_diagnostics() {
+        printf 'FAIL: control-plane rejection attempted boot diagnostics\n' >&2
+        return 1
+    }
+
+    _try_vm_create() {
+        local vm_rg_name="$1"
+        local vm_size="$4"
+        local attempt_count
+        attempt_count=$(wc -l < "${attempts_file}")
+        printf '%s\n' "${vm_size}" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "${vm_size}" "${vm_rg_name}" >> "${events_file}"
+
+        if [[ ${attempt_count} -eq 0 ]]; then
+            echo "RETRYABLE_VM_CREATE_ERROR"
+            return 1
+        fi
+
+        [[ "${vm_rg_name}" == "test-rg-2" ]] || return 2
+        echo '{"powerState":"VM running"}'
+    }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*|"storage account create "*)
+                return 0
+                ;;
+            "vm list --resource-group "*)
+                printf 'vm:list:%s\n' "$4" >> "${events_file}"
+                echo "test-vm"
+                return 0
+                ;;
+            "group delete "*)
+                printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm show "*)
+                echo "/subscriptions/test/resourceGroups/test-rg-2/providers/Microsoft.Network/networkInterfaces/test-nic"
+                return 0
+                ;;
+            "network nic show "*)
+                if [[ "$*" == *"ipConfigurations[0].name"* ]]; then
+                    echo "test-ip-config"
+                else
+                    echo "test-nic"
+                fi
+                return 0
+                ;;
+            "network nic ip-config update")
+                return 0
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    get_vm_rg_name() { echo "test-rg-2"; }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+
+    if ! create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: control-plane fallback did not rotate away from the residual VM\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\nvm:list:test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2\ncreate:fallback-sku@test-rg-2'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: residual-VM fallback order was incorrect\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg-2" ]]; then
+        printf 'FAIL: residual-VM fallback did not retain the replacement resource group\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: control-plane fallback rotates when a VM resource remains\n'
+}
+
+assert_no_cleanup_preserves_timeout_resource_group() {
+    local events_file="${TEST_TMPDIR}/no-cleanup-events"
+    local attempts_file="${TEST_TMPDIR}/no-cleanup-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+    capture_failed_vm_boot_diagnostics() {
+        printf 'diagnostics:capture:%s\n' "$1" >> "${events_file}"
+    }
+    _try_vm_create() {
+        printf '%s\n' "$4" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
+        echo "PROVISIONING_TIMEOUT"
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*|"storage account create "*)
+                return 0
+                ;;
+            "group delete "*)
+                printf 'FAIL: --no-cleanup scheduled resource-group deletion\n' >&2
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    AZ_MAX_PROVISIONING_TIMEOUTS=2
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+    NO_CLEANUP=true
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: --no-cleanup timeout unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\ndiagnostics:capture:test-rg-1'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: --no-cleanup did not preserve the first failed resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "$(wc -l < "${attempts_file}")" -ne 1 || "${VM_RG}" != "test-rg-1" ]]; then
+        printf 'FAIL: --no-cleanup continued fallback or lost resource-group ownership\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: --no-cleanup preserves the timed-out resource group\n'
+}
+
+assert_no_cleanup_preserves_resource_group_on_region_fallback() {
+    local events_file="${TEST_TMPDIR}/no-cleanup-region-events"
+    local attempts_file="${TEST_TMPDIR}/no-cleanup-region-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+    check_image_replicated_to_region() { return 0; }
+    _try_vm_create() {
+        printf '%s@%s\n' "$4" "$5" >> "${attempts_file}"
+        printf 'create:%s@%s/%s\n' "$4" "$1" "$5" >> "${events_file}"
+        echo "RETRYABLE_VM_CREATE_ERROR"
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*|"storage account create "*)
+                return 0
+                ;;
+            "vm list --resource-group "*)
+                printf 'vm:list:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "group delete "*)
+                printf 'FAIL: --no-cleanup deleted the primary-region resource group\n' >&2
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=only-sku
+    AZ_BACKUP_VM_SIZES_AMD64=""
+    AZ_BACKUP_REGIONS=backup-region
+    AZ_REGION=primary-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+    NO_CLEANUP=true
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: --no-cleanup region fallback unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:only-sku@test-rg-1/primary-region\nvm:list:test-rg-1'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: --no-cleanup region fallback did not preserve the primary resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "$(wc -l < "${attempts_file}")" -ne 1 || "${VM_RG}" != "test-rg-1" ]]; then
+        printf 'FAIL: --no-cleanup attempted the backup region or lost resource-group ownership\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: --no-cleanup preserves the resource group across region fallback\n'
+}
+
+assert_cleanup_failure_preserves_resource_group() {
+    local events_file="${TEST_TMPDIR}/cleanup-failure-events"
+    local attempts_file="${TEST_TMPDIR}/cleanup-failure-attempts"
+    : > "${events_file}"
+    : > "${attempts_file}"
+
+    info() { :; }
+    warn() { :; }
+    error() { :; }
+    _try_vm_create() {
+        printf '%s\n' "$4" >> "${attempts_file}"
+        printf 'create:%s@%s\n' "$4" "$1" >> "${events_file}"
+        echo "RETRYABLE_VM_CREATE_ERROR"
+        return 1
+    }
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*|"storage account create "*)
+                return 0
+                ;;
+            "vm list --resource-group "*)
+                printf 'vm:list:%s\n' "$4" >> "${events_file}"
+                echo "test-vm"
+                return 0
+                ;;
+            "group delete "*)
+                printf 'group:delete:failed:%s\n' "$4" >> "${events_file}"
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    BOARD=amd64-usr
+    AZ_VM_SIZE=primary-sku
+    AZ_BACKUP_VM_SIZES_AMD64=fallback-sku
+    AZ_BACKUP_REGIONS=""
+    AZ_REGION=test-region
+    ACG_IMAGE_VERSION_ID=test-image-id
+    RESOURCE_TAGS=(createdBy=test)
+    VM_NAME=test-vm
+    VM_RG=test-rg-1
+    NO_CLEANUP=false
+
+    if create_vm_azure test-rg-1 test-image-id >/dev/null; then
+        printf 'FAIL: fallback continued after resource-group cleanup failed\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg-1\ncreate:primary-sku@test-rg-1\nvm:list:test-rg-1\ngroup:delete:failed:test-rg-1'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: cleanup failure did not stop with the original resource group\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "$(wc -l < "${attempts_file}")" -ne 1 || "${VM_RG}" != "test-rg-1" ]]; then
+        printf 'FAIL: cleanup failure continued fallback or lost resource-group ownership\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: cleanup failure preserves resource-group ownership\n'
 }
 
 assert_resource_group_failure_stops_fallback() {
@@ -760,6 +1110,7 @@ assert_public_ip_failure_cleans_resource_group() {
     : > "${events_file}"
 
     info() { :; }
+    warn() { :; }
 
     az() {
         case "${1:-} ${2:-} ${3:-} ${4:-}" in
@@ -800,8 +1151,116 @@ assert_public_ip_failure_cleans_resource_group() {
             "${expected_events}" "${actual_events}" >&2
         return 1
     fi
+    if [[ -n "${VM_RG}" ]]; then
+        printf 'FAIL: successful partial resource-group cleanup retained ownership\n' >&2
+        return 1
+    fi
 
     printf 'PASS: public-IP failure cleans up its partial resource group\n'
+}
+
+assert_partial_resource_group_cleanup_failure_preserves_ownership() {
+    local events_file="${TEST_TMPDIR}/partial-cleanup-failure-events"
+    : > "${events_file}"
+
+    info() { :; }
+    warn() { :; }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                printf 'public-ip:create:failed\n' >> "${events_file}"
+                return 1
+                ;;
+            "group delete "*)
+                printf 'group:delete:failed:%s\n' "$4" >> "${events_file}"
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    VM_RG=""
+    NO_CLEANUP=false
+    if create_vm_resource_group \
+        test-rg test-region test-public-ip createdBy=test; then
+        printf 'FAIL: partial resource-group setup unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg\npublic-ip:create:failed\ngroup:delete:failed:test-rg'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: partial cleanup failure had unexpected command order\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg" ]]; then
+        printf 'FAIL: partial cleanup failure lost resource-group ownership\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: partial cleanup failure preserves resource-group ownership\n'
+}
+
+assert_no_cleanup_preserves_partial_resource_group() {
+    local events_file="${TEST_TMPDIR}/partial-no-cleanup-events"
+    : > "${events_file}"
+
+    info() { :; }
+    warn() { :; }
+
+    az() {
+        case "${1:-} ${2:-} ${3:-} ${4:-}" in
+            "group create "*)
+                printf 'group:create:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "network public-ip create "*)
+                printf 'public-ip:create:failed\n' >> "${events_file}"
+                return 1
+                ;;
+            "group delete "*)
+                printf 'FAIL: --no-cleanup deleted a partially configured resource group\n' >&2
+                return 1
+                ;;
+            *)
+                printf 'Unexpected az command: %q\n' "$*" >&2
+                return 1
+                ;;
+        esac
+    }
+
+    VM_RG=""
+    NO_CLEANUP=true
+    if create_vm_resource_group \
+        test-rg test-region test-public-ip createdBy=test; then
+        printf 'FAIL: partial resource-group setup unexpectedly succeeded\n' >&2
+        return 1
+    fi
+
+    local expected_events actual_events
+    expected_events=$'group:create:test-rg\npublic-ip:create:failed'
+    actual_events=$(cat "${events_file}")
+    if [[ "${actual_events}" != "${expected_events}" ]]; then
+        printf 'FAIL: --no-cleanup partial setup had unexpected command order\nExpected:\n%s\nActual:\n%s\n' \
+            "${expected_events}" "${actual_events}" >&2
+        return 1
+    fi
+    if [[ "${VM_RG}" != "test-rg" ]]; then
+        printf 'FAIL: --no-cleanup partial setup lost resource-group ownership\n' >&2
+        return 1
+    fi
+
+    printf 'PASS: --no-cleanup preserves partially configured resource groups\n'
 }
 
 assert_boot_diagnostics_storage_is_provisioned() {
@@ -888,6 +1347,9 @@ assert_final_candidate_does_not_create_unused_resource_group() {
                 ;;
             "group delete "*)
                 printf 'group:delete:%s\n' "$4" >> "${events_file}"
+                return 0
+                ;;
+            "vm list --resource-group "*)
                 return 0
                 ;;
             *)
@@ -985,8 +1447,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
                 printf 'group:delete:%s\n' "$4" >> "${events_file}"
                 return 0
                 ;;
-            "vm delete -g "*)
-                printf 'vm:delete:%s\n' "$4" >> "${events_file}"
+            "vm list --resource-group "*)
                 return 0
                 ;;
             "vm show "*)
@@ -1031,7 +1492,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
     fi
 
     local expected_events actual_events
-    expected_events=$'group:create:test-rg-1/primary-region\ncreate:only-sku@test-rg-1/primary-region\nvm:delete:test-rg-1\ngroup:delete:test-rg-1\ngroup:create:test-rg-2/backup-region\ncreate:only-sku@test-rg-2/backup-region'
+    expected_events=$'group:create:test-rg-1/primary-region\ncreate:only-sku@test-rg-1/primary-region\ngroup:delete:test-rg-1\ngroup:create:test-rg-2/backup-region\ncreate:only-sku@test-rg-2/backup-region'
     actual_events=$(cat "${events_file}")
     if [[ "${actual_events}" != "${expected_events}" ]]; then
         printf 'FAIL: backup-region fallback created an intermediate resource group\nExpected:\n%s\nActual:\n%s\n' \
@@ -1048,6 +1509,7 @@ assert_final_candidate_moves_directly_to_backup_region() {
 
 ( assert_failed_vm_boot_diagnostics )
 ( assert_vm_size_family_parsing )
+( assert_resource_group_name_generation )
 ( assert_timeout_configuration_validation )
 ( assert_provisioning_timeouts_are_bounded )
 ( assert_single_provisioning_timeout_limit )
@@ -1055,8 +1517,14 @@ assert_final_candidate_moves_directly_to_backup_region() {
 ( assert_mixed_failures_keep_generic_terminal_error )
 ( assert_fallback_uses_clean_resource_group )
 ( assert_control_plane_failure_reuses_resource_group )
+( assert_control_plane_failure_with_vm_rotates_resource_group )
+( assert_no_cleanup_preserves_timeout_resource_group )
+( assert_no_cleanup_preserves_resource_group_on_region_fallback )
+( assert_cleanup_failure_preserves_resource_group )
 ( assert_resource_group_failure_stops_fallback )
 ( assert_public_ip_failure_cleans_resource_group )
+( assert_partial_resource_group_cleanup_failure_preserves_ownership )
+( assert_no_cleanup_preserves_partial_resource_group )
 ( assert_boot_diagnostics_storage_is_provisioned )
 ( assert_final_candidate_does_not_create_unused_resource_group )
 ( assert_final_candidate_moves_directly_to_backup_region )

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -484,9 +484,9 @@ _cancel_vm_create() {
     exit "$status"
 }
 
-# Attempt a single az vm create. Returns 0 on success, 1 for an incompatible
-# SKU, 2 for a fatal error, 3 for a retryable OS provisioning error, or 4 for
-# a retryable allocation error.
+# Attempt a single az vm create.  Returns 0 on success, 1 on a retryable
+# candidate failure, or 2 on a non-retryable failure.  Retryable failures print
+# "RETRYABLE_VM_CREATE_ERROR" so the caller can advance to the next candidate.
 _try_vm_create() {
     local vm_rg_name="$1"
     local vm_name="$2"
@@ -580,30 +580,30 @@ _try_vm_create() {
         _VM_CREATE_RESULT="$output"
         return 0
     else
-        # Detect errors that mean "this SKU won't work here" so the caller
-        # can move on to the next candidate instead of aborting.
-        #   - SkuNotAvailable        → capacity restriction in this region
-        #   - InvalidParameter/vmSize → disk-controller incompatibility
-        #   - TrustedLaunch           → SKU does not support TrustedLaunch security type
+        # Detect candidate-specific or transient provisioning errors so the
+        # caller can move on to the next SKU/region instead of aborting.
+        #   - SkuNotAvailable / AllocationFailed → regional capacity restriction
+        #   - OSProvisioningTimedOut              → transient provisioning failure
+        #   - OperationNotAllowed + quota/cores   → subscription quota restriction
+        #   - InvalidParameter/vmSize             → disk-controller incompatibility
+        #   - TrustedLaunch                       → unsupported security type
+        local retryable=false
         if echo "$output" | grep -qiE \
-            "SkuNotAvailable|\"target\":\\s*\"vmSize\"|TrustedLaunch"; then
+            "SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OSProvisioningTimedOut|\"target\":\\s*\"vmSize\"|TrustedLaunch"; then
+            retryable=true
+        elif echo "$output" | grep -qi "OperationNotAllowed" && \
+            echo "$output" | grep -qiE "quota|cores"; then
+            retryable=true
+        fi
+
+        if [[ "$retryable" == "true" ]]; then
             # Log the error details to stderr so they appear in pipeline logs
             echo "$output" | grep -iE \
-                'SkuNotAvailable|Capacity|InvalidParameter|vmSize|TrustedLaunch|BadRequest' >&2 || true
-            _VM_CREATE_RESULT="SKU_NOT_AVAILABLE"
+                'SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OSProvisioningTimedOut|OperationNotAllowed|Capacity|Quota|InvalidParameter|vmSize|TrustedLaunch|BadRequest' >&2 || true
+            echo "RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
-        if echo "$output" | grep -qi "OSProvisioningTimedOut"; then
-            echo "$output" >&2
-            _VM_CREATE_RESULT="RETRYABLE_OS_PROVISIONING"
-            return 3
-        fi
-        if echo "$output" | grep -qiE "ZonalAllocationFailed|AllocationFailed"; then
-            echo "$output" >&2
-            _VM_CREATE_RESULT="RETRYABLE_ALLOCATION"
-            return 4
-        fi
-        # Non-SKU error — print the full output so the caller sees it, then fail
+        # Non-retryable error — print the full output so the caller sees it, then fail
         echo "$output" >&2
         return 2
     fi
@@ -948,18 +948,10 @@ create_vm_azure() {
                     --name "$VM_NAME" \
                     --resource-group "$vm_rg_name"
                 return 0
-            elif [[ $rc -eq 1 && "$result" == "SKU_NOT_AVAILABLE" ]]; then
-                warn "✗ SKU incompatible or unavailable: ${sku} in ${region} — trying next candidate"
-                _replace_vm_rg "$vm_rg_name" "$region" "${all_tags[@]}"
-                vm_rg_name="$VM_RG"
-                continue
-            # Repeated allocation failures are regional capacity noise, so try
-            # another candidate. Repeated OS provisioning timeouts likely
-            # indicate an image defect and intentionally remain fatal.
-            elif [[ $rc -eq 4 && "$result" == "RETRYABLE_ALLOCATION" ]]; then
-                warn "✗ Allocation failed twice for ${sku} in ${region} — trying next candidate"
-                _replace_vm_rg "$vm_rg_name" "$region" "${all_tags[@]}"
-                vm_rg_name="$VM_RG"
+            elif [[ $rc -eq 1 && "$result" == "RETRYABLE_VM_CREATE_ERROR" ]]; then
+                warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
+                # Delete the failed VM resource (deployment may have left artifacts)
+                az vm delete -g "$vm_rg_name" -n "$VM_NAME" -y --no-wait 2>/dev/null || true
                 continue
             else
                 # Non-SKU failure — fatal

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -181,6 +181,7 @@ create_vm_resource_group() {
     info "Creating VM RG: $vm_rg_name (location: $region)"
     if ! az group create \
         --name "$vm_rg_name" \
+        --subscription "$AZ_SUB_ID" \
         --location "$region" \
         --tags "${tags[@]}"; then
         return 1
@@ -190,6 +191,7 @@ create_vm_resource_group() {
     info "Creating public IP with policy-compliant tags: $public_ip_name"
     if ! az network public-ip create \
         --name "$public_ip_name" \
+        --subscription "$AZ_SUB_ID" \
         --resource-group "$vm_rg_name" \
         --location "$region" \
         --allocation-method Static \
@@ -210,6 +212,7 @@ create_vm_resource_group() {
     info "Creating boot diagnostics storage account: $boot_diagnostics_storage_name"
     if ! az storage account create \
         --name "$boot_diagnostics_storage_name" \
+        --subscription "$AZ_SUB_ID" \
         --resource-group "$vm_rg_name" \
         --location "$region" \
         --sku Standard_LRS \

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -38,7 +38,6 @@ fi
 VM_RG_PREFIX="${VM_RG_PREFIX:-$(whoami)-acl-test-vm-rg}"
 VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"
-_VM_CREATE_RESULT=""
 AZ_MAX_PROVISIONING_TIMEOUTS="${AZ_MAX_PROVISIONING_TIMEOUTS:-2}"
 
 validate_azure_configuration() {
@@ -660,7 +659,6 @@ _try_vm_create() {
     local region="$5"
     shift 5
     local -a extra_tags=("$@")
-    _VM_CREATE_RESULT=""
     _enforce_arm_security_contract || return 2
     local boot_diagnostics_storage_name
     boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
@@ -698,35 +696,6 @@ _try_vm_create() {
     trap '_cancel_vm_create "$create_pid" "$output_file" "$vm_rg_name" 130' INT
     trap '_cancel_vm_create "$create_pid" "$output_file" "$vm_rg_name" 143' TERM
 
-    # The CLI cannot request managed boot diagnostics directly on `vm create`.
-    # Enable it as soon as the VM resource exists, while provisioning is still
-    # running, so OS provisioning failures retain their serial console output.
-    local diagnostics_elapsed=0
-    local diagnostics_next_probe=0
-    local diagnostics_backoff=2
-    local diagnostics_poll_interval=2
-    local diagnostics_max_wait=300
-    while kill -0 "$create_pid" 2>/dev/null && [[ $diagnostics_elapsed -lt $diagnostics_max_wait ]]; do
-        if [[ $diagnostics_elapsed -ge $diagnostics_next_probe ]]; then
-            if az vm show --resource-group "$vm_rg_name" --name "$vm_name" \
-                --only-show-errors >/dev/null 2>&1; then
-                if az vm boot-diagnostics enable \
-                    --resource-group "$vm_rg_name" \
-                    --name "$vm_name" \
-                    --only-show-errors >/dev/null 2>&1; then
-                    break
-                fi
-            fi
-            diagnostics_next_probe=$(( diagnostics_elapsed + diagnostics_backoff ))
-            diagnostics_backoff=$(( diagnostics_backoff * 2 ))
-            if [[ $diagnostics_backoff -gt 30 ]]; then
-                diagnostics_backoff=30
-            fi
-        fi
-        sleep "$diagnostics_poll_interval"
-        diagnostics_elapsed=$(( diagnostics_elapsed + diagnostics_poll_interval ))
-    done
-
     if wait "$create_pid"; then
         rc=0
     else
@@ -745,7 +714,7 @@ _try_vm_create() {
     fi
 
     if [[ $rc -eq 0 ]]; then
-        _VM_CREATE_RESULT="$output"
+        printf '%s\n' "$output"
         return 0
     else
         # A provisioning timeout usually points to a guest/image boot problem,
@@ -845,130 +814,183 @@ _validate_arm_vm_size() {
     fi
 }
 
-_collect_failed_vm_diagnostics() {
-    local vm_rg_name="$1"
-    local vm_name="$2"
-    local label="$3"
-    local diagnostics_base="${BUILD_ARTIFACTSTAGINGDIRECTORY:-${TMPDIR:-/tmp}}"
-    local diagnostics_root="${DIAGNOSTICS_DIR:-${diagnostics_base}/acl-vm-diagnostics}"
-    local safe_label latest_deployment
-    local instance_view_file instance_view_error
-    local boot_log_file boot_log_error
-    local deployments_file deployments_error
-    local deployment_operations_file deployment_operations_error
+_has_untimed_out_vm_family() {
+    local -n _candidate_skus_ref="$1"
+    local -n _timed_out_families_ref="$2"
+    local sku family
 
-    safe_label=$(printf '%s' "${vm_rg_name}-${label}" | tr -c '[:alnum:]_.-' '_')
-    instance_view_file="${diagnostics_root}/${safe_label}-instance-view.json"
-    instance_view_error="${diagnostics_root}/${safe_label}-instance-view.err"
-    boot_log_file="${diagnostics_root}/${safe_label}-boot.log"
-    boot_log_error="${diagnostics_root}/${safe_label}-boot.err"
-    deployments_file="${diagnostics_root}/${safe_label}-deployments.json"
-    deployments_error="${diagnostics_root}/${safe_label}-deployments.err"
-    deployment_operations_file="${diagnostics_root}/${safe_label}-deployment-operations.json"
-    deployment_operations_error="${diagnostics_root}/${safe_label}-deployment-operations.err"
+    for sku in "${_candidate_skus_ref[@]}"; do
+        family=$(get_vm_size_family "$sku")
+        if [[ -z "${_timed_out_families_ref[$family]:-}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
 
-    if ! mkdir -p "$diagnostics_root"; then
-        warn "Could not create diagnostics directory ${diagnostics_root}; continuing with VM cleanup"
+_get_eligible_vm_skus_for_region() {
+    local region="$1"
+    local -n _candidate_skus_ref="$2"
+    local -n _timed_out_families_ref="$3"
+    local -n _eligible_skus_ref="$4"
+    local sku family
+
+    _eligible_skus_ref=()
+    for sku in "${_candidate_skus_ref[@]}"; do
+        if [[ "${BOARD:-amd64-usr}" == "arm64-usr" ]] &&
+            ! _validate_arm_vm_size "$sku" "$region"; then
+            continue
+        fi
+
+        family=$(get_vm_size_family "$sku")
+        if [[ -n "${_timed_out_families_ref[$family]:-}" ]]; then
+            info "Skipping SKU=${sku}: family ${family} already timed out provisioning"
+            continue
+        fi
+        _eligible_skus_ref+=("$sku")
+    done
+}
+
+_prepare_vm_attempt_resource_group() {
+    local -n _vm_rg_name_ref="$1"
+    local -n _current_rg_region_ref="$2"
+    local region="$3"
+    local public_ip_name="$4"
+    shift 4
+    local -a tags=("$@")
+
+    if [[ -n "$_vm_rg_name_ref" &&
+        -n "$_current_rg_region_ref" &&
+        "$_current_rg_region_ref" != "$region" ]]; then
+        info "Switching from ${_current_rg_region_ref} to ${region}; recreating resource group"
+        if ! schedule_failed_vm_rg_cleanup \
+            "$_vm_rg_name_ref" "region fallback from ${_current_rg_region_ref} to ${region}"; then
+            error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
+            return 1
+        fi
+        _vm_rg_name_ref=""
+        VM_RG=""
+        _current_rg_region_ref=""
+    fi
+
+    if [[ -z "$_vm_rg_name_ref" ]]; then
+        _vm_rg_name_ref=$(get_vm_rg_name)
+    fi
+    if [[ "$_current_rg_region_ref" == "$region" ]]; then
         return 0
     fi
-    info "Collecting failed VM diagnostics in ${diagnostics_root}"
 
-    if ! az vm get-instance-view \
-        --resource-group "$vm_rg_name" \
-        --name "$vm_name" \
-        --output json \
-        >"$instance_view_file" \
-        2>"$instance_view_error"; then
-        warn "Could not collect instance view for ${label}; see ${instance_view_error}"
+    if ! create_vm_resource_group \
+        "$_vm_rg_name_ref" "$region" "$public_ip_name" "${tags[@]}"; then
+        error "Failed to prepare resource group '${_vm_rg_name_ref}'"
+        return 1
     fi
-
-    if ! az vm boot-diagnostics get-boot-log \
-        --resource-group "$vm_rg_name" \
-        --name "$vm_name" \
-        --output tsv \
-        >"$boot_log_file" \
-        2>"$boot_log_error"; then
-        warn "Could not collect boot log for ${label}; see ${boot_log_error}"
-        if [[ -s "$boot_log_error" ]]; then
-            head -c 300 "$boot_log_error" >&2 || warn "Could not print boot-log error from ${boot_log_error}"
-            printf '\n' >&2
-        fi
-    elif [[ -s "$boot_log_file" ]]; then
-        info "--- Azure VM boot log (${label}), last 200 lines ---"
-        tail -n 200 "$boot_log_file" >&2 || warn "Could not print boot log from ${boot_log_file}"
-    else
-        warn "Azure returned an empty boot log for ${label}"
-    fi
-
-    if ! az deployment group list \
-        --resource-group "$vm_rg_name" \
-        --output json \
-        >"$deployments_file" \
-        2>"$deployments_error"; then
-        warn "Could not collect deployments for ${label}; see ${deployments_error}"
-    fi
-
-    if ! latest_deployment=$(az deployment group list \
-        --resource-group "$vm_rg_name" \
-        --query "sort_by(@, &properties.timestamp)[-1].name" \
-        --output tsv 2>"$deployment_operations_error"); then
-        warn "Could not identify the latest deployment for ${label}; see ${deployment_operations_error}"
-        latest_deployment=""
-    fi
-    if [[ -n "$latest_deployment" ]]; then
-        if ! az deployment operation group list \
-            --resource-group "$vm_rg_name" \
-            --name "$latest_deployment" \
-            --output json \
-            >"$deployment_operations_file" \
-            2>"$deployment_operations_error"; then
-            warn "Could not collect deployment operations for ${label}; see ${deployment_operations_error}"
-        fi
-    fi
+    VM_RG="$_vm_rg_name_ref"
+    _current_rg_region_ref="$region"
 }
 
-_create_vm_rg_resources() {
+_attach_vm_public_ip() {
     local vm_rg_name="$1"
-    local region="$2"
-    shift 2
-    local -a all_tags=("$@")
+    local vm_name="$2"
+    local public_ip_name="$3"
+    local nic_id nic_name ip_config_name
 
-    info "Creating VM RG: $vm_rg_name (location: $region)"
-    az group create \
-        --name "$vm_rg_name" \
-        --location "$region" \
-        --tags "${all_tags[@]}"
-
-    local public_ip_name="${VM_NAME}PublicIP"
-    info "Creating public IP with policy-compliant tags: $public_ip_name"
-    az network public-ip create \
-        --name "$public_ip_name" \
+    if ! nic_id=$(az vm show -g "$vm_rg_name" -n "$vm_name" \
+        --query 'networkProfile.networkInterfaces[0].id' -o tsv); then
+        error "Failed to identify the VM network interface"
+        return 1
+    fi
+    if ! nic_name=$(az network nic show --ids "$nic_id" --query 'name' -o tsv); then
+        error "Failed to identify the VM network interface name"
+        return 1
+    fi
+    if ! ip_config_name=$(az network nic show --ids "$nic_id" \
+        --query 'ipConfigurations[0].name' -o tsv); then
+        error "Failed to identify the VM IP configuration"
+        return 1
+    fi
+    if ! az network nic ip-config update \
+        --nic-name "$nic_name" \
         --resource-group "$vm_rg_name" \
-        --location "$region" \
-        --allocation-method Static \
-        --sku Standard \
-        --ip-tags FirstPartyUsage=/NonProd \
-        --tags "${all_tags[@]}"
+        --name "$ip_config_name" \
+        --public-ip-address "$public_ip_name"; then
+        error "Failed to attach public IP ${public_ip_name} to ${vm_name}"
+        return 1
+    fi
 }
 
-_replace_vm_rg() {
-    local old_vm_rg_name="$1"
-    local region="$2"
-    shift 2
-    local -a all_tags=("$@")
+_handle_provisioning_timeout() {
+    local -n _vm_rg_name_ref="$1"
+    local -n _current_rg_region_ref="$2"
+    local -n _timeout_count_ref="$3"
+    local -n _timeout_combos_ref="$4"
+    local -n _timed_out_families_ref="$5"
+    local sku="$6"
+    local sku_family="$7"
+    local region="$8"
 
-    if ! _delete_vm_rg_sync "$old_vm_rg_name"; then
-        warn "Synchronous deletion failed for ${old_vm_rg_name}; scheduling asynchronous cleanup and continuing with a fresh resource group"
-        if ! az group delete \
-            --name "$old_vm_rg_name" \
-            --subscription "$AZ_SUB_ID" \
-            --yes \
-            --no-wait; then
-            warn "Could not schedule asynchronous deletion of ${old_vm_rg_name}; manual cleanup may be required"
+    ((_timeout_count_ref++)) || true
+    _timed_out_families_ref["$sku_family"]=1
+    _timeout_combos_ref+=("${sku}@${region}")
+    warn "✗ OS provisioning timed out: ${sku} in ${region} (family ${sku_family}, ${_timeout_count_ref}/${AZ_MAX_PROVISIONING_TIMEOUTS})"
+
+    capture_failed_vm_boot_diagnostics \
+        "$_vm_rg_name_ref" "$VM_NAME" "$sku" "$region" || true
+    if ! schedule_failed_vm_rg_cleanup \
+        "$_vm_rg_name_ref" "OS provisioning timeout"; then
+        error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
+        return 1
+    fi
+    _vm_rg_name_ref=""
+    VM_RG=""
+    _current_rg_region_ref=""
+
+    if ((_timeout_count_ref >= AZ_MAX_PROVISIONING_TIMEOUTS)); then
+        error "VM provisioning timed out on ${_timeout_count_ref} distinct SKU families; likely image boot failure"
+        error "  Timed out: ${_timeout_combos_ref[*]}"
+        return 1
+    fi
+}
+
+_handle_retryable_vm_create_error() {
+    local -n _vm_rg_name_ref="$1"
+    local -n _current_rg_region_ref="$2"
+
+    if vm_resource_absent "$_vm_rg_name_ref" "$VM_NAME"; then
+        warn "✗ Retryable VM creation failure left no VM resource; reusing ${_vm_rg_name_ref}"
+        return 0
+    fi
+
+    warn "✗ Retryable VM creation failure left a VM or could not confirm its absence; rotating resource groups"
+    if ! schedule_failed_vm_rg_cleanup \
+        "$_vm_rg_name_ref" "retryable VM creation failure"; then
+        error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
+        return 1
+    fi
+    _vm_rg_name_ref=""
+    VM_RG=""
+    _current_rg_region_ref=""
+}
+
+_report_vm_fallback_failure() {
+    local candidate_skus_name="$1"
+    local timed_out_families_name="$2"
+    local -n _timeout_combos_ref="$3"
+    local -n _tried_combos_ref="$4"
+    local timeout_count="$5"
+
+    if ! _has_untimed_out_vm_family \
+        "$candidate_skus_name" "$timed_out_families_name"; then
+        error "All configured VM SKU families timed out provisioning; likely image boot failure"
+        error "  Note: a family that times out is skipped in all remaining regions"
+        error "  Timed out: ${_timeout_combos_ref[*]}"
+    else
+        error "No VM candidate succeeded across all candidate regions"
+        if ((timeout_count > 0)); then
+            error "  Provisioning timeouts: ${_timeout_combos_ref[*]}"
         fi
     fi
-    VM_RG=$(get_vm_rg_name)
-    _create_vm_rg_resources "$VM_RG" "$region" "${all_tags[@]}"
+    error "  Tried: ${_tried_combos_ref[*]}"
 }
 
 create_vm_azure() {
@@ -1032,16 +1054,7 @@ create_vm_azure() {
     info "  Regions: ${all_regions[*]}"
 
     for region in "${all_regions[@]}"; do
-        local region_has_candidate=false
-        local candidate_sku candidate_family
-        for candidate_sku in "${unique_skus[@]}"; do
-            candidate_family=$(get_vm_size_family "$candidate_sku")
-            if [[ -z "${timed_out_families[$candidate_family]:-}" ]]; then
-                region_has_candidate=true
-                break
-            fi
-        done
-        if [[ "$region_has_candidate" != "true" ]]; then
+        if ! _has_untimed_out_vm_family unique_skus timed_out_families; then
             break
         fi
 
@@ -1056,49 +1069,22 @@ create_vm_azure() {
         fi
 
         local region_skus=()
-        for sku in "${unique_skus[@]}"; do
-            if [[ "${BOARD:-amd64-usr}" == "arm64-usr" ]] && ! _validate_arm_vm_size "$sku" "$region"; then
-                continue
-            fi
-            sku_family=$(get_vm_size_family "$sku")
-            if [[ -n "${timed_out_families[$sku_family]:-}" ]]; then
-                info "Skipping SKU=${sku}: family ${sku_family} already timed out provisioning"
-                continue
-            fi
-            region_skus+=("$sku")
-        done
+        _get_eligible_vm_skus_for_region \
+            "$region" unique_skus timed_out_families region_skus
         if [[ ${#region_skus[@]} -eq 0 ]]; then
             warn "No compatible VM SKU candidates in ${region} — skipping region"
             continue
         fi
 
-        if [[ -n "$vm_rg_name" && -n "$current_rg_region" && "$current_rg_region" != "$region" ]]; then
-            info "Switching from ${current_rg_region} to ${region}; recreating resource group"
-            if ! schedule_failed_vm_rg_cleanup \
-                "$vm_rg_name" "region fallback from ${current_rg_region} to ${region}"; then
-                error "Stopping fallback because resource group ${vm_rg_name} was preserved"
-                return 1
-            fi
-            vm_rg_name=""
-            VM_RG=""
-            current_rg_region=""
-        fi
-
         local sku sku_family
         for sku in "${region_skus[@]}"; do
             sku_family=$(get_vm_size_family "$sku")
-            if [[ -z "$vm_rg_name" ]]; then
-                vm_rg_name=$(get_vm_rg_name)
+            if ! _prepare_vm_attempt_resource_group \
+                vm_rg_name current_rg_region "$region" "$public_ip_name" \
+                "${all_tags[@]}"; then
+                return 1
             fi
-            if [[ "$current_rg_region" != "$region" ]]; then
-                if ! create_vm_resource_group \
-                    "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
-                    error "Failed to prepare resource group '${vm_rg_name}'"
-                    return 1
-                fi
-                VM_RG="$vm_rg_name"
-                current_rg_region="$region"
-            fi
+
             tried_combos+=("${sku}@${region}")
             local result rc
             result=$(_try_vm_create \
@@ -1114,59 +1100,24 @@ create_vm_azure() {
                 AZ_REGION="$region"
 
                 info "Attaching public IP to VM NIC..."
-                local nic_id
-                nic_id=$(az vm show -g "$vm_rg_name" -n "$VM_NAME" \
-                    --query 'networkProfile.networkInterfaces[0].id' -o tsv)
-                local nic_name
-                nic_name=$(az network nic show --ids "$nic_id" --query 'name' -o tsv)
-                local ip_config_name
-                ip_config_name=$(az network nic show --ids "$nic_id" \
-                    --query 'ipConfigurations[0].name' -o tsv)
-                az network nic ip-config update \
-                    --nic-name "$nic_name" \
-                    --resource-group "$vm_rg_name" \
-                    --name "$ip_config_name" \
-                    --public-ip-address "$public_ip_name"
+                if ! _attach_vm_public_ip \
+                    "$vm_rg_name" "$VM_NAME" "$public_ip_name"; then
+                    return 1
+                fi
                 return 0
             elif [[ $rc -eq 1 && ( "$result" == "RETRYABLE_VM_CREATE_ERROR" || "$result" == "PROVISIONING_TIMEOUT" ) ]]; then
                 if [[ "$result" == "PROVISIONING_TIMEOUT" ]]; then
-                    ((provisioning_timeout_count++)) || true
-                    timed_out_families[$sku_family]=1
-                    provisioning_timeout_combos+=("${sku}@${region}")
-                    warn "✗ OS provisioning timed out: ${sku} in ${region} (family ${sku_family}, ${provisioning_timeout_count}/${AZ_MAX_PROVISIONING_TIMEOUTS})"
-
-                    # A timeout may leave a VM, NIC, disk, or deployment behind.
-                    # Isolate the next attempt instead of racing their deletion.
-                    capture_failed_vm_boot_diagnostics \
-                        "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
-                    if ! schedule_failed_vm_rg_cleanup \
-                        "$vm_rg_name" "OS provisioning timeout"; then
-                        error "Stopping fallback because resource group ${vm_rg_name} was preserved"
+                    if ! _handle_provisioning_timeout \
+                        vm_rg_name current_rg_region \
+                        provisioning_timeout_count provisioning_timeout_combos \
+                        timed_out_families "$sku" "$sku_family" "$region"; then
                         return 1
                     fi
-                    vm_rg_name=""
-                    VM_RG=""
-                    current_rg_region=""
                 else
-                    if vm_resource_absent "$vm_rg_name" "$VM_NAME"; then
-                        warn "✗ Retryable VM creation failure left no VM resource; reusing ${vm_rg_name}"
-                    else
-                        warn "✗ Retryable VM creation failure left a VM or could not confirm its absence; rotating resource groups"
-                        if ! schedule_failed_vm_rg_cleanup \
-                            "$vm_rg_name" "retryable VM creation failure"; then
-                            error "Stopping fallback because resource group ${vm_rg_name} was preserved"
-                            return 1
-                        fi
-                        vm_rg_name=""
-                        VM_RG=""
-                        current_rg_region=""
+                    if ! _handle_retryable_vm_create_error \
+                        vm_rg_name current_rg_region; then
+                        return 1
                     fi
-                fi
-
-                if ((provisioning_timeout_count >= AZ_MAX_PROVISIONING_TIMEOUTS)); then
-                    error "VM provisioning timed out on ${provisioning_timeout_count} distinct SKU families; likely image boot failure"
-                    error "  Timed out: ${provisioning_timeout_combos[*]}"
-                    return 1
                 fi
                 continue
             else
@@ -1178,26 +1129,9 @@ create_vm_azure() {
         done
     done
 
-    local all_families_timed_out=true
-    for candidate_sku in "${unique_skus[@]}"; do
-        candidate_family=$(get_vm_size_family "$candidate_sku")
-        if [[ -z "${timed_out_families[$candidate_family]:-}" ]]; then
-            all_families_timed_out=false
-            break
-        fi
-    done
-
-    if [[ "$all_families_timed_out" == "true" ]]; then
-        error "All configured VM SKU families timed out provisioning; likely image boot failure"
-        error "  Note: a family that times out is skipped in all remaining regions"
-        error "  Timed out: ${provisioning_timeout_combos[*]}"
-    else
-        error "No VM candidate succeeded across all candidate regions"
-        if ((provisioning_timeout_count > 0)); then
-            error "  Provisioning timeouts: ${provisioning_timeout_combos[*]}"
-        fi
-    fi
-    error "  Tried: ${tried_combos[*]}"
+    _report_vm_fallback_failure \
+        unique_skus timed_out_families provisioning_timeout_combos \
+        tried_combos "$provisioning_timeout_count"
     return 1
 }
 

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -164,6 +164,13 @@ get_vm_size_family() {
     fi
 }
 
+get_boot_diagnostics_storage_name() {
+    local vm_rg_name="$1"
+    local digest
+    digest=$(printf '%s' "${AZ_SUB_ID}:${vm_rg_name}" | sha256sum)
+    printf 'bootdiag%s\n' "${digest:0:16}"
+}
+
 create_vm_resource_group() {
     local vm_rg_name="$1"
     local region="$2"
@@ -191,6 +198,24 @@ create_vm_resource_group() {
         az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
         return 1
     fi
+
+    # azure-cli 2.88 cannot request managed diagnostics during `az vm create`
+    # (Azure/azure-cli#30340), so use an account co-located with each VM attempt.
+    local boot_diagnostics_storage_name
+    boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
+    info "Creating boot diagnostics storage account: $boot_diagnostics_storage_name"
+    if ! az storage account create \
+        --name "$boot_diagnostics_storage_name" \
+        --resource-group "$vm_rg_name" \
+        --location "$region" \
+        --sku Standard_LRS \
+        --kind StorageV2 \
+        --min-tls-version TLS1_2 \
+        --allow-blob-public-access false \
+        --tags "${tags[@]}"; then
+        az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+        return 1
+    fi
 }
 
 capture_failed_vm_boot_diagnostics() {
@@ -199,17 +224,21 @@ capture_failed_vm_boot_diagnostics() {
     local vm_size="$3"
     local region="$4"
 
-    if ! az vm show -g "$vm_rg_name" -n "$vm_name" &>/dev/null; then
+    local diagnostics_enabled
+    if ! diagnostics_enabled=$(az vm show \
+        -g "$vm_rg_name" -n "$vm_name" \
+        --query 'diagnosticsProfile.bootDiagnostics.enabled' -o tsv 2>/dev/null); then
         info "No VM resource available for boot diagnostics"
         return 0
     fi
 
-    # azure-cli 2.88 cannot enable managed diagnostics in `az vm create`
-    # (Azure/azure-cli#30340), so earlier boot output may be unavailable.
-    warn "Attempting post-failure boot diagnostics: SKU=${vm_size} Region=${region}"
-    az vm boot-diagnostics enable \
-        --resource-group "$vm_rg_name" \
-        --name "$vm_name" &>/dev/null || true
+    warn "Retrieving failed VM boot diagnostics: SKU=${vm_size} Region=${region}"
+    if [[ "${diagnostics_enabled,,}" != "true" ]]; then
+        warn "Boot diagnostics were not enabled during provisioning; attempting post-failure enablement"
+        az vm boot-diagnostics enable \
+            --resource-group "$vm_rg_name" \
+            --name "$vm_name" &>/dev/null || true
+    fi
 
     local boot_log_err_file
     if ! boot_log_err_file=$(mktemp); then
@@ -590,7 +619,8 @@ _try_vm_create() {
     local image_id="$3"
     local vm_size="$4"
     local region="$5"
-    shift 5
+    local boot_diagnostics_storage_name="$6"
+    shift 6
     local -a extra_tags=("$@")
     _VM_CREATE_RESULT=""
     _enforce_arm_security_contract || return 2
@@ -607,6 +637,7 @@ _try_vm_create() {
         --image "$image_id"
         --location "$region"
         --public-ip-address ""
+        --boot-diagnostics-storage "$boot_diagnostics_storage_name"
         --tags "${extra_tags[@]}"
     )
 
@@ -685,7 +716,6 @@ _try_vm_create() {
             return 1
         fi
         # Detect candidate-specific errors so the caller can move on to the
-        # next SKU/region instead of aborting.
         # next SKU/region instead of aborting.
         #   - SkuNotAvailable / AllocationFailed → regional capacity restriction
         #   - OperationNotAllowed + quota/cores   → subscription quota restriction
@@ -955,6 +985,8 @@ create_vm_azure() {
     local provisioning_timeout_count=0
     local provisioning_timeout_combos=()
     local -A timed_out_families=()
+    local current_rg_region=""
+    local boot_diagnostics_storage_name=""
 
     info "VM SKU fallback candidates:"
     info "  SKUs:    ${unique_skus[*]}"
@@ -1001,53 +1033,36 @@ create_vm_azure() {
             continue
         fi
 
-        # The prior region's last attempted candidate already deleted its RG.
+        if [[ -n "$vm_rg_name" && -n "$current_rg_region" && "$current_rg_region" != "$region" ]]; then
+            info "Switching from ${current_rg_region} to ${region}; recreating resource group"
+            az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+            vm_rg_name=""
+            VM_RG=""
+            current_rg_region=""
+        fi
         if [[ -z "$vm_rg_name" ]]; then
             vm_rg_name=$(get_vm_rg_name)
         fi
-        if ! create_vm_resource_group \
-            "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
-            error "Failed to prepare resource group '${vm_rg_name}'"
-            return 1
+        if [[ "$current_rg_region" != "$region" ]]; then
+            if ! create_vm_resource_group \
+                "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
+                error "Failed to prepare resource group '${vm_rg_name}'"
+                return 1
+            fi
+            VM_RG="$vm_rg_name"
+            current_rg_region="$region"
+            boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
         fi
-        VM_RG="$vm_rg_name"
 
         local sku_index sku sku_family
         for ((sku_index = 0; sku_index < ${#region_skus[@]}; sku_index++)); do
             sku="${region_skus[$sku_index]}"
             sku_family=$(get_vm_size_family "$sku")
             tried_combos+=("${sku}@${region}")
-            local attempt=1
-            local max_attempts=2
             local result rc
-
-            while [[ $attempt -le $max_attempts ]]; do
-                info "Attempting VM creation: SKU=${sku} Region=${region} Attempt=${attempt}/${max_attempts}..."
-
-                # Invoke directly so this shell owns the background Azure CLI
-                # process and can clean it up if the validator is interrupted.
-                if _try_vm_create "$vm_rg_name" "$VM_NAME" "$image_id" "$sku" "$region" "${all_tags[@]}"; then
-                    rc=0
-                else
-                    rc=$?
-                fi
-                result="$_VM_CREATE_RESULT"
-
-                if [[ $rc -ne 0 && ( $rc -ne 1 || "$result" != "SKU_NOT_AVAILABLE" ) ]]; then
-                    _collect_failed_vm_diagnostics \
-                        "$vm_rg_name" "$VM_NAME" \
-                        "${sku}-${region}-attempt${attempt}"
-                fi
-
-                if [[ ( $rc -eq 3 || $rc -eq 4 ) && $attempt -lt $max_attempts ]]; then
-                    warn "Retryable VM creation failure for ${sku} in ${region}; recreating the full resource group before one retry"
-                    _replace_vm_rg "$vm_rg_name" "$region" "${all_tags[@]}"
-                    vm_rg_name="$VM_RG"
-                    attempt=$(( attempt + 1 ))
-                    continue
-                fi
-                break
-            done
+            result=$(_try_vm_create \
+                "$vm_rg_name" "$VM_NAME" "$image_id" "$sku" "$region" \
+                "$boot_diagnostics_storage_name" "${all_tags[@]}") && rc=0 || rc=$?
 
             if [[ $rc -eq 0 ]]; then
                 echo "$result"  # Print the az vm create JSON output
@@ -1083,15 +1098,20 @@ create_vm_azure() {
                     timed_out_families[$sku_family]=1
                     provisioning_timeout_combos+=("${sku}@${region}")
                     warn "✗ OS provisioning timed out: ${sku} in ${region} (family ${sku_family}, ${provisioning_timeout_count}/${AZ_MAX_PROVISIONING_TIMEOUTS})"
+
+                    # A timeout may leave a VM, NIC, disk, or deployment behind.
+                    # Isolate the next attempt instead of racing their deletion.
+                    capture_failed_vm_boot_diagnostics \
+                        "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
+                    az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+                    vm_rg_name=""
+                    VM_RG=""
+                    current_rg_region=""
+                    boot_diagnostics_storage_name=""
                 else
                     warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
+                    az vm delete -g "$vm_rg_name" -n "$VM_NAME" -y --no-wait 2>/dev/null || true
                 fi
-                # A provisioning timeout may leave a VM, NIC, disk, or deployment
-                # behind. Isolate the next attempt instead of racing their deletion.
-                capture_failed_vm_boot_diagnostics \
-                    "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
-                az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
-                vm_rg_name=""
 
                 if ((provisioning_timeout_count >= AZ_MAX_PROVISIONING_TIMEOUTS)); then
                     error "VM provisioning timed out on ${provisioning_timeout_count} distinct SKU families; likely image boot failure"
@@ -1108,7 +1128,7 @@ create_vm_azure() {
                         break
                     fi
                 done
-                if [[ "$has_remaining_candidate" == "true" ]]; then
+                if [[ "$has_remaining_candidate" == "true" && -z "$vm_rg_name" ]]; then
                     vm_rg_name=$(get_vm_rg_name)
                     if ! create_vm_resource_group \
                         "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
@@ -1116,6 +1136,8 @@ create_vm_azure() {
                         return 1
                     fi
                     VM_RG="$vm_rg_name"
+                    current_rg_region="$region"
+                    boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
                 fi
                 continue
             else
@@ -1138,6 +1160,7 @@ create_vm_azure() {
 
     if [[ "$all_families_timed_out" == "true" ]]; then
         error "All configured VM SKU families timed out provisioning; likely image boot failure"
+        error "  Note: a family that times out is skipped in all remaining regions"
         error "  Timed out: ${provisioning_timeout_combos[*]}"
     else
         error "No VM candidate succeeded across all candidate regions"

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -39,6 +39,14 @@ VM_RG_PREFIX="${VM_RG_PREFIX:-$(whoami)-acl-test-vm-rg}"
 VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"
 _VM_CREATE_RESULT=""
+AZ_MAX_PROVISIONING_TIMEOUTS="${AZ_MAX_PROVISIONING_TIMEOUTS:-2}"
+
+validate_azure_configuration() {
+    if ! [[ "$AZ_MAX_PROVISIONING_TIMEOUTS" =~ ^[1-9][0-9]*$ ]]; then
+        error "AZ_MAX_PROVISIONING_TIMEOUTS must be a positive integer"
+        return 1
+    fi
+}
 
 # Backup VM SKUs to try when the primary SKU cannot be provisioned.
 # Ordered by preference:
@@ -147,6 +155,15 @@ check_image_replicated_to_region() {
     echo "$regions" | grep -qxF "$target_lower"
 }
 
+get_vm_size_family() {
+    local vm_size="${1#Standard_}"
+    if [[ "$vm_size" =~ ^([[:alpha:]]+)[0-9]+(.*)$ ]]; then
+        printf '%s%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    else
+        printf '%s\n' "$vm_size"
+    fi
+}
+
 create_vm_resource_group() {
     local vm_rg_name="$1"
     local region="$2"
@@ -187,25 +204,42 @@ capture_failed_vm_boot_diagnostics() {
         return 0
     fi
 
-    warn "Capturing boot diagnostics for failed VM: SKU=${vm_size} Region=${region}"
+    # azure-cli 2.88 cannot enable managed diagnostics in `az vm create`
+    # (Azure/azure-cli#30340), so earlier boot output may be unavailable.
+    warn "Attempting post-failure boot diagnostics: SKU=${vm_size} Region=${region}"
     az vm boot-diagnostics enable \
         --resource-group "$vm_rg_name" \
         --name "$vm_name" &>/dev/null || true
 
-    local boot_log_json
-    if boot_log_json=$(az vm boot-diagnostics get-boot-log \
+    local boot_log_err_file
+    if ! boot_log_err_file=$(mktemp); then
+        warn "Unable to create temporary file for boot diagnostics"
+        return 0
+    fi
+
+    local boot_log
+    if boot_log=$(az vm boot-diagnostics get-boot-log \
         --resource-group "$vm_rg_name" \
-        --name "$vm_name" -o json 2>&1); then
-        local boot_log
-        if boot_log=$(jq -r . <<< "$boot_log_json" 2>/dev/null); then
+        --name "$vm_name" -o tsv 2>"$boot_log_err_file"); then
+        if [[ -s "$boot_log_err_file" ]]; then
+            warn "Azure CLI warnings while retrieving boot diagnostics:"
+            tail -20 "$boot_log_err_file" | sed 's/^/  [az] /' >&2 || true
+        fi
+        if [[ -n "$boot_log" ]]; then
             info "Failed VM serial console log (last 200 lines):"
             tail -200 <<< "$boot_log" | sed 's/^/  [serial] /' >&2 || true
         else
-            warn "Failed to decode boot diagnostics output"
+            warn "Boot diagnostics returned an empty serial console log"
         fi
     else
-        warn "Boot diagnostics unavailable: $boot_log_json"
+        local boot_log_error
+        boot_log_error=$(tail -20 "$boot_log_err_file" 2>/dev/null || true)
+        warn "Boot diagnostics unavailable${boot_log_error:+: $boot_log_error}"
+        if [[ -n "$boot_log" ]]; then
+            tail -200 <<< "$boot_log" | sed 's/^/  [serial] /' >&2 || true
+        fi
     fi
+    rm -f "$boot_log_err_file" || true
 
     return 0
 }
@@ -548,8 +582,8 @@ _cancel_vm_create() {
 }
 
 # Attempt a single az vm create.  Returns 0 on success, 1 on a retryable
-# candidate failure, or 2 on a non-retryable failure.  Retryable failures print
-# "RETRYABLE_VM_CREATE_ERROR" so the caller can advance to the next candidate.
+# candidate failure, or 2 on a non-retryable failure. Retryable failures print
+# a marker so the caller can apply the appropriate fallback policy.
 _try_vm_create() {
     local vm_rg_name="$1"
     local vm_name="$2"
@@ -643,16 +677,23 @@ _try_vm_create() {
         _VM_CREATE_RESULT="$output"
         return 0
     else
-        # Detect candidate-specific or transient provisioning errors so the
-        # caller can move on to the next SKU/region instead of aborting.
+        # A provisioning timeout usually points to a guest/image boot problem,
+        # so let the caller apply a stricter retry limit than capacity errors.
+        if echo "$output" | grep -qi "OSProvisioningTimedOut"; then
+            echo "$output" | grep -i "OSProvisioningTimedOut" >&2 || true
+            echo "PROVISIONING_TIMEOUT"
+            return 1
+        fi
+        # Detect candidate-specific errors so the caller can move on to the
+        # next SKU/region instead of aborting.
+        # next SKU/region instead of aborting.
         #   - SkuNotAvailable / AllocationFailed → regional capacity restriction
-        #   - OSProvisioningTimedOut              → transient provisioning failure
         #   - OperationNotAllowed + quota/cores   → subscription quota restriction
         #   - InvalidParameter/vmSize             → disk-controller incompatibility
         #   - TrustedLaunch                       → unsupported security type
         local retryable=false
         if echo "$output" | grep -qiE \
-            "SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OSProvisioningTimedOut|\"target\":\\s*\"vmSize\"|TrustedLaunch"; then
+            "SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|\"target\":\\s*\"vmSize\"|TrustedLaunch"; then
             retryable=true
         elif echo "$output" | grep -qi "OperationNotAllowed" && \
             echo "$output" | grep -qiE "quota|cores"; then
@@ -662,7 +703,7 @@ _try_vm_create() {
         if [[ "$retryable" == "true" ]]; then
             # Log the error details to stderr so they appear in pipeline logs
             echo "$output" | grep -iE \
-                'SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OSProvisioningTimedOut|OperationNotAllowed|Capacity|Quota|InvalidParameter|vmSize|TrustedLaunch|BadRequest' >&2 || true
+                'SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OperationNotAllowed|Capacity|Quota|InvalidParameter|vmSize|TrustedLaunch|BadRequest' >&2 || true
             echo "RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
@@ -864,6 +905,8 @@ create_vm_azure() {
     local vm_rg_name="$1"
     local image_version_or_id="$2"
 
+    validate_azure_configuration || return 1
+
     local image_id
     if [[ -n "${ACG_IMAGE_VERSION_ID}" ]]; then
         image_id="${image_version_or_id}"
@@ -907,15 +950,30 @@ create_vm_azure() {
     local all_tags=("${RESOURCE_TAGS[@]}" "purpose=VM-testing" "creationTime=$(date +%s)")
     local original_sku="${AZ_VM_SIZE}"
     local original_region="${AZ_REGION}"
-    local current_rg_region=""
     local tried_combos=()
     local public_ip_name="${VM_NAME}PublicIP"
+    local provisioning_timeout_count=0
+    local provisioning_timeout_combos=()
+    local -A timed_out_families=()
 
     info "VM SKU fallback candidates:"
     info "  SKUs:    ${unique_skus[*]}"
     info "  Regions: ${all_regions[*]}"
 
     for region in "${all_regions[@]}"; do
+        local region_has_candidate=false
+        local candidate_sku candidate_family
+        for candidate_sku in "${unique_skus[@]}"; do
+            candidate_family=$(get_vm_size_family "$candidate_sku")
+            if [[ -z "${timed_out_families[$candidate_family]:-}" ]]; then
+                region_has_candidate=true
+                break
+            fi
+        done
+        if [[ "$region_has_candidate" != "true" ]]; then
+            break
+        fi
+
         # For non-primary regions, verify the gallery image is replicated there
         if [[ "$region" != "${original_region}" ]]; then
             info "Checking image replication to ${region}..."
@@ -931,6 +989,11 @@ create_vm_azure() {
             if [[ "${BOARD:-amd64-usr}" == "arm64-usr" ]] && ! _validate_arm_vm_size "$sku" "$region"; then
                 continue
             fi
+            sku_family=$(get_vm_size_family "$sku")
+            if [[ -n "${timed_out_families[$sku_family]:-}" ]]; then
+                info "Skipping SKU=${sku}: family ${sku_family} already timed out provisioning"
+                continue
+            fi
             region_skus+=("$sku")
         done
         if [[ ${#region_skus[@]} -eq 0 ]]; then
@@ -938,29 +1001,21 @@ create_vm_azure() {
             continue
         fi
 
-        # Create or recreate resource group if we're in a new region
-        if [[ "$region" != "$current_rg_region" ]]; then
-            if [[ -n "$current_rg_region" ]]; then
-                info "Switching from ${current_rg_region} to ${region} — recreating resource group"
-                az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
-                vm_rg_name=$(get_vm_rg_name)
-            elif [[ -z "$vm_rg_name" ]]; then
-                # The last candidate in the prior region already deleted its RG.
-                vm_rg_name=$(get_vm_rg_name)
-            fi
-            if ! create_vm_resource_group \
-                "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
-                error "Failed to prepare resource group '${vm_rg_name}'"
-                return 1
-            fi
-
-            VM_RG="$vm_rg_name"
-            current_rg_region="$region"
+        # The prior region's last attempted candidate already deleted its RG.
+        if [[ -z "$vm_rg_name" ]]; then
+            vm_rg_name=$(get_vm_rg_name)
         fi
+        if ! create_vm_resource_group \
+            "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
+            error "Failed to prepare resource group '${vm_rg_name}'"
+            return 1
+        fi
+        VM_RG="$vm_rg_name"
 
-        local sku_index sku
+        local sku_index sku sku_family
         for ((sku_index = 0; sku_index < ${#region_skus[@]}; sku_index++)); do
             sku="${region_skus[$sku_index]}"
+            sku_family=$(get_vm_size_family "$sku")
             tried_combos+=("${sku}@${region}")
             local attempt=1
             local max_attempts=2
@@ -1022,14 +1077,38 @@ create_vm_azure() {
                     --name "$VM_NAME" \
                     --resource-group "$vm_rg_name"
                 return 0
-            elif [[ $rc -eq 1 && "$result" == "RETRYABLE_VM_CREATE_ERROR" ]]; then
-                warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
+            elif [[ $rc -eq 1 && ( "$result" == "RETRYABLE_VM_CREATE_ERROR" || "$result" == "PROVISIONING_TIMEOUT" ) ]]; then
+                if [[ "$result" == "PROVISIONING_TIMEOUT" ]]; then
+                    ((provisioning_timeout_count++)) || true
+                    timed_out_families[$sku_family]=1
+                    provisioning_timeout_combos+=("${sku}@${region}")
+                    warn "✗ OS provisioning timed out: ${sku} in ${region} (family ${sku_family}, ${provisioning_timeout_count}/${AZ_MAX_PROVISIONING_TIMEOUTS})"
+                else
+                    warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
+                fi
                 # A provisioning timeout may leave a VM, NIC, disk, or deployment
                 # behind. Isolate the next attempt instead of racing their deletion.
                 capture_failed_vm_boot_diagnostics \
                     "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
                 az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
-                if ((sku_index + 1 < ${#region_skus[@]})); then
+                vm_rg_name=""
+
+                if ((provisioning_timeout_count >= AZ_MAX_PROVISIONING_TIMEOUTS)); then
+                    error "VM provisioning timed out on ${provisioning_timeout_count} distinct SKU families; likely image boot failure"
+                    error "  Timed out: ${provisioning_timeout_combos[*]}"
+                    return 1
+                fi
+
+                local has_remaining_candidate=false
+                local next_index next_family
+                for ((next_index = sku_index + 1; next_index < ${#region_skus[@]}; next_index++)); do
+                    next_family=$(get_vm_size_family "${region_skus[$next_index]}")
+                    if [[ -z "${timed_out_families[$next_family]:-}" ]]; then
+                        has_remaining_candidate=true
+                        break
+                    fi
+                done
+                if [[ "$has_remaining_candidate" == "true" ]]; then
                     vm_rg_name=$(get_vm_rg_name)
                     if ! create_vm_resource_group \
                         "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
@@ -1037,10 +1116,6 @@ create_vm_azure() {
                         return 1
                     fi
                     VM_RG="$vm_rg_name"
-                else
-                    # Let the next replicated region create its RG, if one remains.
-                    vm_rg_name=""
-                    current_rg_region=""
                 fi
                 continue
             else
@@ -1052,7 +1127,24 @@ create_vm_azure() {
         done
     done
 
-    error "No VM candidate succeeded across all candidate regions"
+    local all_families_timed_out=true
+    for candidate_sku in "${unique_skus[@]}"; do
+        candidate_family=$(get_vm_size_family "$candidate_sku")
+        if [[ -z "${timed_out_families[$candidate_family]:-}" ]]; then
+            all_families_timed_out=false
+            break
+        fi
+    done
+
+    if [[ "$all_families_timed_out" == "true" ]]; then
+        error "All configured VM SKU families timed out provisioning; likely image boot failure"
+        error "  Timed out: ${provisioning_timeout_combos[*]}"
+    else
+        error "No VM candidate succeeded across all candidate regions"
+        if ((provisioning_timeout_count > 0)); then
+            error "  Provisioning timeouts: ${provisioning_timeout_combos[*]}"
+        fi
+    fi
     error "  Tried: ${tried_combos[*]}"
     return 1
 }
@@ -1179,6 +1271,9 @@ remove_vm_azure() {
 
 check_azure_prereqs() {
     info "Checking Azure prerequisites..."
+    if ! validate_azure_configuration; then
+        return 1
+    fi
     if ! command -v az &>/dev/null; then
         error "Azure CLI (az) not found"
         return 1

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -185,6 +185,7 @@ create_vm_resource_group() {
         --tags "${tags[@]}"; then
         return 1
     fi
+    VM_RG="$vm_rg_name"
 
     info "Creating public IP with policy-compliant tags: $public_ip_name"
     if ! az network public-ip create \
@@ -195,7 +196,10 @@ create_vm_resource_group() {
         --sku Standard \
         --ip-tags FirstPartyUsage=/NonProd \
         --tags "${tags[@]}"; then
-        az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+        if schedule_failed_vm_rg_cleanup \
+            "$vm_rg_name" "public IP creation failure"; then
+            VM_RG=""
+        fi
         return 1
     fi
 
@@ -213,7 +217,10 @@ create_vm_resource_group() {
         --min-tls-version TLS1_2 \
         --allow-blob-public-access false \
         --tags "${tags[@]}"; then
-        az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+        if schedule_failed_vm_rg_cleanup \
+            "$vm_rg_name" "boot diagnostics storage creation failure"; then
+            VM_RG=""
+        fi
         return 1
     fi
 }
@@ -231,36 +238,77 @@ capture_failed_vm_boot_diagnostics() {
 
     warn "Retrieving failed VM boot diagnostics: SKU=${vm_size} Region=${region}"
 
-    local boot_log_err_file
+    local boot_log_file boot_log_err_file
+    if ! boot_log_file=$(mktemp); then
+        warn "Unable to create temporary file for the boot log"
+        return 0
+    fi
     if ! boot_log_err_file=$(mktemp); then
-        warn "Unable to create temporary file for boot diagnostics"
+        warn "Unable to create temporary file for boot diagnostics errors"
+        rm -f "$boot_log_file" || true
         return 0
     fi
 
-    local boot_log
-    if boot_log=$(az vm boot-diagnostics get-boot-log \
+    local serial_log_uri
+    if ! serial_log_uri=$(az vm boot-diagnostics get-boot-log-uris \
         --resource-group "$vm_rg_name" \
-        --name "$vm_name" -o tsv 2>"$boot_log_err_file"); then
-        if [[ -s "$boot_log_err_file" ]]; then
-            warn "Azure CLI warnings while retrieving boot diagnostics:"
-            tail -20 "$boot_log_err_file" | sed 's/^/  [az] /' >&2 || true
-        fi
-        if [[ -n "$boot_log" ]]; then
+        --name "$vm_name" \
+        --query serialConsoleLogBlobUri \
+        -o tsv 2>"$boot_log_err_file"); then
+        warn "Could not retrieve the serial-console log URI"
+    elif [[ -z "$serial_log_uri" || "$serial_log_uri" == "null" ]]; then
+        warn "Azure returned no serial-console log URI"
+    elif az storage blob download \
+        --blob-url "$serial_log_uri" \
+        --file "$boot_log_file" \
+        --overwrite true \
+        --no-progress \
+        --only-show-errors \
+        --output none 2>>"$boot_log_err_file"; then
+        if [[ -s "$boot_log_file" ]]; then
             info "Failed VM serial console log (last 200 lines):"
-            tail -200 <<< "$boot_log" | sed 's/^/  [serial] /' >&2 || true
+            tail -200 "$boot_log_file" | sed 's/^/  [serial] /' >&2 || true
         else
             warn "Boot diagnostics returned an empty serial console log"
         fi
     else
-        local boot_log_error
-        boot_log_error=$(tail -20 "$boot_log_err_file" 2>/dev/null || true)
-        warn "Boot diagnostics unavailable${boot_log_error:+: $boot_log_error}"
-        if [[ -n "$boot_log" ]]; then
-            tail -200 <<< "$boot_log" | sed 's/^/  [serial] /' >&2 || true
-        fi
+        # Do not print the captured Azure CLI error because it may contain the SAS URI.
+        warn "Could not download the serial-console boot log"
     fi
-    rm -f "$boot_log_err_file" || true
+    rm -f "$boot_log_file" "$boot_log_err_file" || true
 
+    return 0
+}
+
+vm_resource_absent() {
+    local vm_rg_name="$1"
+    local vm_name="$2"
+    local vm_names
+
+    if ! vm_names=$(az vm list \
+        --resource-group "$vm_rg_name" \
+        --query '[].name' \
+        -o tsv 2>/dev/null); then
+        warn "Could not confirm whether VM ${vm_name} remains in ${vm_rg_name}"
+        return 1
+    fi
+
+    ! grep -qxF "$vm_name" <<< "$vm_names"
+}
+
+schedule_failed_vm_rg_cleanup() {
+    local vm_rg_name="$1"
+    local reason="$2"
+
+    if [[ "${NO_CLEANUP:-false}" == "true" ]]; then
+        warn "--no-cleanup: preserving resource group ${vm_rg_name} after ${reason}"
+        return 1
+    fi
+
+    if ! az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null; then
+        warn "Could not schedule deletion of ${vm_rg_name}; manual cleanup may be required"
+        return 1
+    fi
     return 0
 }
 
@@ -1026,7 +1074,11 @@ create_vm_azure() {
 
         if [[ -n "$vm_rg_name" && -n "$current_rg_region" && "$current_rg_region" != "$region" ]]; then
             info "Switching from ${current_rg_region} to ${region}; recreating resource group"
-            az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+            if ! schedule_failed_vm_rg_cleanup \
+                "$vm_rg_name" "region fallback from ${current_rg_region} to ${region}"; then
+                error "Stopping fallback because resource group ${vm_rg_name} was preserved"
+                return 1
+            fi
             vm_rg_name=""
             VM_RG=""
             current_rg_region=""
@@ -1087,13 +1139,28 @@ create_vm_azure() {
                     # Isolate the next attempt instead of racing their deletion.
                     capture_failed_vm_boot_diagnostics \
                         "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
-                    az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+                    if ! schedule_failed_vm_rg_cleanup \
+                        "$vm_rg_name" "OS provisioning timeout"; then
+                        error "Stopping fallback because resource group ${vm_rg_name} was preserved"
+                        return 1
+                    fi
                     vm_rg_name=""
                     VM_RG=""
                     current_rg_region=""
                 else
-                    warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
-                    az vm delete -g "$vm_rg_name" -n "$VM_NAME" -y --no-wait 2>/dev/null || true
+                    if vm_resource_absent "$vm_rg_name" "$VM_NAME"; then
+                        warn "✗ Retryable VM creation failure left no VM resource; reusing ${vm_rg_name}"
+                    else
+                        warn "✗ Retryable VM creation failure left a VM or could not confirm its absence; rotating resource groups"
+                        if ! schedule_failed_vm_rg_cleanup \
+                            "$vm_rg_name" "retryable VM creation failure"; then
+                            error "Stopping fallback because resource group ${vm_rg_name} was preserved"
+                            return 1
+                        fi
+                        vm_rg_name=""
+                        VM_RG=""
+                        current_rg_region=""
+                    fi
                 fi
 
                 if ((provisioning_timeout_count >= AZ_MAX_PROVISIONING_TIMEOUTS)); then
@@ -1136,7 +1203,7 @@ create_vm_azure() {
 
 get_vm_rg_name() {
     local suffix
-    suffix=$(tr -dc 'a-z0-9' </dev/urandom | head -c 8)
+    suffix=$(od -An -N4 -tx1 /dev/urandom | tr -d '[:space:]')
     printf '%s-%s\n' "$VM_RG_PREFIX" "$suffix"
 }
 

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -40,7 +40,7 @@ VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"
 _VM_CREATE_RESULT=""
 
-# Backup VM SKUs to try when the primary SKU has capacity restrictions.
+# Backup VM SKUs to try when the primary SKU cannot be provisioned.
 # Ordered by preference:
 #   AMD64 — v5 D-family (SCSI) first, then cross-family (F/B), then v6 (NVMe,
 #           may fail with disk-controller incompatibility on current images).
@@ -145,6 +145,35 @@ check_image_replicated_to_region() {
 
     local target_lower="${target_region,,}"
     echo "$regions" | grep -qxF "$target_lower"
+}
+
+create_vm_resource_group() {
+    local vm_rg_name="$1"
+    local region="$2"
+    local public_ip_name="$3"
+    shift 3
+    local -a tags=("$@")
+
+    info "Creating VM RG: $vm_rg_name (location: $region)"
+    if ! az group create \
+        --name "$vm_rg_name" \
+        --location "$region" \
+        --tags "${tags[@]}"; then
+        return 1
+    fi
+
+    info "Creating public IP with policy-compliant tags: $public_ip_name"
+    if ! az network public-ip create \
+        --name "$public_ip_name" \
+        --resource-group "$vm_rg_name" \
+        --location "$region" \
+        --allocation-method Static \
+        --sku Standard \
+        --ip-tags FirstPartyUsage=/NonProd \
+        --tags "${tags[@]}"; then
+        az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+        return 1
+    fi
 }
 
 # ── Azure console ─────────────────────────────────────────────────
@@ -846,6 +875,7 @@ create_vm_azure() {
     local original_region="${AZ_REGION}"
     local current_rg_region=""
     local tried_combos=()
+    local public_ip_name="${VM_NAME}PublicIP"
 
     info "VM SKU fallback candidates:"
     info "  SKUs:    ${unique_skus[*]}"
@@ -878,15 +908,25 @@ create_vm_azure() {
         if [[ "$region" != "$current_rg_region" ]]; then
             if [[ -n "$current_rg_region" ]]; then
                 info "Switching from ${current_rg_region} to ${region} — recreating resource group"
-                _replace_vm_rg "$vm_rg_name" "$region" "${all_tags[@]}"
-                vm_rg_name="$VM_RG"
-            else
-                _create_vm_rg_resources "$vm_rg_name" "$region" "${all_tags[@]}"
+                az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+                vm_rg_name=$(get_vm_rg_name)
+            elif [[ -z "$vm_rg_name" ]]; then
+                # The last candidate in the prior region already deleted its RG.
+                vm_rg_name=$(get_vm_rg_name)
             fi
+            if ! create_vm_resource_group \
+                "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
+                error "Failed to prepare resource group '${vm_rg_name}'"
+                return 1
+            fi
+
+            VM_RG="$vm_rg_name"
             current_rg_region="$region"
         fi
 
-        for sku in "${region_skus[@]}"; do
+        local sku_index sku
+        for ((sku_index = 0; sku_index < ${#region_skus[@]}; sku_index++)); do
+            sku="${region_skus[$sku_index]}"
             tried_combos+=("${sku}@${region}")
             local attempt=1
             local max_attempts=2
@@ -950,11 +990,25 @@ create_vm_azure() {
                 return 0
             elif [[ $rc -eq 1 && "$result" == "RETRYABLE_VM_CREATE_ERROR" ]]; then
                 warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
-                # Delete the failed VM resource (deployment may have left artifacts)
-                az vm delete -g "$vm_rg_name" -n "$VM_NAME" -y --no-wait 2>/dev/null || true
+                # A provisioning timeout may leave a VM, NIC, disk, or deployment
+                # behind. Isolate the next attempt instead of racing their deletion.
+                az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
+                if ((sku_index + 1 < ${#region_skus[@]})); then
+                    vm_rg_name=$(get_vm_rg_name)
+                    if ! create_vm_resource_group \
+                        "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
+                        error "Failed to prepare a clean resource group before retrying"
+                        return 1
+                    fi
+                    VM_RG="$vm_rg_name"
+                else
+                    # Let the next replicated region create its RG, if one remains.
+                    vm_rg_name=""
+                    current_rg_region=""
+                fi
                 continue
             else
-                # Non-SKU failure — fatal
+                # Non-retryable failure — fatal
                 error "VM creation failed with a non-recoverable error (exit code: ${rc})"
                 _delete_vm_rg_sync "$vm_rg_name"
                 return 1
@@ -962,8 +1016,7 @@ create_vm_azure() {
         done
     done
 
-    _delete_vm_rg_sync "$vm_rg_name"
-    error "No available VM SKU found across all candidate regions"
+    error "No VM candidate succeeded across all candidate regions"
     error "  Tried: ${tried_combos[*]}"
     return 1
 }

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -304,7 +304,12 @@ schedule_failed_vm_rg_cleanup() {
         return 1
     fi
 
-    if ! az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null; then
+    if ! az group delete \
+        -n "$vm_rg_name" \
+        --subscription "$AZ_SUB_ID" \
+        -y \
+        --no-wait \
+        2>/dev/null; then
         warn "Could not schedule deletion of ${vm_rg_name}; manual cleanup may be required"
         return 1
     fi
@@ -1128,6 +1133,13 @@ create_vm_azure() {
             fi
         done
     done
+
+    if [[ -n "$vm_rg_name" ]] &&
+        schedule_failed_vm_rg_cleanup \
+            "$vm_rg_name" "all VM candidates exhausted"; then
+        vm_rg_name=""
+        VM_RG=""
+    fi
 
     _report_vm_fallback_failure \
         unique_skus timed_out_families provisioning_timeout_combos \

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -224,21 +224,12 @@ capture_failed_vm_boot_diagnostics() {
     local vm_size="$3"
     local region="$4"
 
-    local diagnostics_enabled
-    if ! diagnostics_enabled=$(az vm show \
-        -g "$vm_rg_name" -n "$vm_name" \
-        --query 'diagnosticsProfile.bootDiagnostics.enabled' -o tsv 2>/dev/null); then
+    if ! az vm show -g "$vm_rg_name" -n "$vm_name" &>/dev/null; then
         info "No VM resource available for boot diagnostics"
         return 0
     fi
 
     warn "Retrieving failed VM boot diagnostics: SKU=${vm_size} Region=${region}"
-    if [[ "${diagnostics_enabled,,}" != "true" ]]; then
-        warn "Boot diagnostics were not enabled during provisioning; attempting post-failure enablement"
-        az vm boot-diagnostics enable \
-            --resource-group "$vm_rg_name" \
-            --name "$vm_name" &>/dev/null || true
-    fi
 
     local boot_log_err_file
     if ! boot_log_err_file=$(mktemp); then
@@ -619,11 +610,12 @@ _try_vm_create() {
     local image_id="$3"
     local vm_size="$4"
     local region="$5"
-    local boot_diagnostics_storage_name="$6"
-    shift 6
+    shift 5
     local -a extra_tags=("$@")
     _VM_CREATE_RESULT=""
     _enforce_arm_security_contract || return 2
+    local boot_diagnostics_storage_name
+    boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
 
     local vm_create_args=(
         --resource-group "$vm_rg_name"
@@ -986,7 +978,6 @@ create_vm_azure() {
     local provisioning_timeout_combos=()
     local -A timed_out_families=()
     local current_rg_region=""
-    local boot_diagnostics_storage_name=""
 
     info "VM SKU fallback candidates:"
     info "  SKUs:    ${unique_skus[*]}"
@@ -1040,29 +1031,27 @@ create_vm_azure() {
             VM_RG=""
             current_rg_region=""
         fi
-        if [[ -z "$vm_rg_name" ]]; then
-            vm_rg_name=$(get_vm_rg_name)
-        fi
-        if [[ "$current_rg_region" != "$region" ]]; then
-            if ! create_vm_resource_group \
-                "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
-                error "Failed to prepare resource group '${vm_rg_name}'"
-                return 1
-            fi
-            VM_RG="$vm_rg_name"
-            current_rg_region="$region"
-            boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
-        fi
 
-        local sku_index sku sku_family
-        for ((sku_index = 0; sku_index < ${#region_skus[@]}; sku_index++)); do
-            sku="${region_skus[$sku_index]}"
+        local sku sku_family
+        for sku in "${region_skus[@]}"; do
             sku_family=$(get_vm_size_family "$sku")
+            if [[ -z "$vm_rg_name" ]]; then
+                vm_rg_name=$(get_vm_rg_name)
+            fi
+            if [[ "$current_rg_region" != "$region" ]]; then
+                if ! create_vm_resource_group \
+                    "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
+                    error "Failed to prepare resource group '${vm_rg_name}'"
+                    return 1
+                fi
+                VM_RG="$vm_rg_name"
+                current_rg_region="$region"
+            fi
             tried_combos+=("${sku}@${region}")
             local result rc
             result=$(_try_vm_create \
                 "$vm_rg_name" "$VM_NAME" "$image_id" "$sku" "$region" \
-                "$boot_diagnostics_storage_name" "${all_tags[@]}") && rc=0 || rc=$?
+                "${all_tags[@]}") && rc=0 || rc=$?
 
             if [[ $rc -eq 0 ]]; then
                 echo "$result"  # Print the az vm create JSON output
@@ -1085,12 +1074,7 @@ create_vm_azure() {
                     --nic-name "$nic_name" \
                     --resource-group "$vm_rg_name" \
                     --name "$ip_config_name" \
-                    --public-ip-address "${VM_NAME}PublicIP"
-
-                info "Enabling boot diagnostics..."
-                az vm boot-diagnostics enable \
-                    --name "$VM_NAME" \
-                    --resource-group "$vm_rg_name"
+                    --public-ip-address "$public_ip_name"
                 return 0
             elif [[ $rc -eq 1 && ( "$result" == "RETRYABLE_VM_CREATE_ERROR" || "$result" == "PROVISIONING_TIMEOUT" ) ]]; then
                 if [[ "$result" == "PROVISIONING_TIMEOUT" ]]; then
@@ -1107,7 +1091,6 @@ create_vm_azure() {
                     vm_rg_name=""
                     VM_RG=""
                     current_rg_region=""
-                    boot_diagnostics_storage_name=""
                 else
                     warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
                     az vm delete -g "$vm_rg_name" -n "$VM_NAME" -y --no-wait 2>/dev/null || true
@@ -1117,27 +1100,6 @@ create_vm_azure() {
                     error "VM provisioning timed out on ${provisioning_timeout_count} distinct SKU families; likely image boot failure"
                     error "  Timed out: ${provisioning_timeout_combos[*]}"
                     return 1
-                fi
-
-                local has_remaining_candidate=false
-                local next_index next_family
-                for ((next_index = sku_index + 1; next_index < ${#region_skus[@]}; next_index++)); do
-                    next_family=$(get_vm_size_family "${region_skus[$next_index]}")
-                    if [[ -z "${timed_out_families[$next_family]:-}" ]]; then
-                        has_remaining_candidate=true
-                        break
-                    fi
-                done
-                if [[ "$has_remaining_candidate" == "true" && -z "$vm_rg_name" ]]; then
-                    vm_rg_name=$(get_vm_rg_name)
-                    if ! create_vm_resource_group \
-                        "$vm_rg_name" "$region" "$public_ip_name" "${all_tags[@]}"; then
-                        error "Failed to prepare a clean resource group before retrying"
-                        return 1
-                    fi
-                    VM_RG="$vm_rg_name"
-                    current_rg_region="$region"
-                    boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
                 fi
                 continue
             else

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -176,6 +176,40 @@ create_vm_resource_group() {
     fi
 }
 
+capture_failed_vm_boot_diagnostics() {
+    local vm_rg_name="$1"
+    local vm_name="$2"
+    local vm_size="$3"
+    local region="$4"
+
+    if ! az vm show -g "$vm_rg_name" -n "$vm_name" &>/dev/null; then
+        info "No VM resource available for boot diagnostics"
+        return 0
+    fi
+
+    warn "Capturing boot diagnostics for failed VM: SKU=${vm_size} Region=${region}"
+    az vm boot-diagnostics enable \
+        --resource-group "$vm_rg_name" \
+        --name "$vm_name" &>/dev/null || true
+
+    local boot_log_json
+    if boot_log_json=$(az vm boot-diagnostics get-boot-log \
+        --resource-group "$vm_rg_name" \
+        --name "$vm_name" -o json 2>&1); then
+        local boot_log
+        if boot_log=$(jq -r . <<< "$boot_log_json" 2>/dev/null); then
+            info "Failed VM serial console log (last 200 lines):"
+            tail -200 <<< "$boot_log" | sed 's/^/  [serial] /' >&2 || true
+        else
+            warn "Failed to decode boot diagnostics output"
+        fi
+    else
+        warn "Boot diagnostics unavailable: $boot_log_json"
+    fi
+
+    return 0
+}
+
 # ── Azure console ─────────────────────────────────────────────────
 
 connect_vm_console_azure() {
@@ -992,6 +1026,8 @@ create_vm_azure() {
                 warn "✗ Retryable VM creation failure: ${sku} in ${region} — trying next candidate"
                 # A provisioning timeout may leave a VM, NIC, disk, or deployment
                 # behind. Isolate the next attempt instead of racing their deletion.
+                capture_failed_vm_boot_diagnostics \
+                    "$vm_rg_name" "$VM_NAME" "$sku" "$region" || true
                 az group delete -n "$vm_rg_name" -y --no-wait 2>/dev/null || true
                 if ((sku_index + 1 < ${#region_skus[@]})); then
                     vm_rg_name=$(get_vm_rg_name)

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -167,7 +167,7 @@ get_vm_size_family() {
 get_boot_diagnostics_storage_name() {
     local vm_rg_name="$1"
     local digest
-    digest=$(printf '%s' "${AZ_SUB_ID}:${vm_rg_name}" | sha256sum)
+    read -r digest _ < <(printf '%s' "${AZ_SUB_ID}:${vm_rg_name}" | sha256sum)
     printf 'bootdiag%s\n' "${digest:0:16}"
 }
 

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -304,13 +304,17 @@ schedule_failed_vm_rg_cleanup() {
         return 1
     fi
 
-    if ! az group delete \
+    local cleanup_error
+    if ! cleanup_error=$(az group delete \
         -n "$vm_rg_name" \
         --subscription "$AZ_SUB_ID" \
         -y \
         --no-wait \
-        2>/dev/null; then
+        2>&1 >/dev/null); then
         warn "Could not schedule deletion of ${vm_rg_name}; manual cleanup may be required"
+        if [[ -n "$cleanup_error" ]]; then
+            warn "  az error: $cleanup_error"
+        fi
         return 1
     fi
     return 0

--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -38,6 +38,7 @@ fi
 VM_RG_PREFIX="${VM_RG_PREFIX:-$(whoami)-acl-test-vm-rg}"
 VM_RG=""
 AZ_VM_ARGS="${AZ_VM_ARGS:-}"
+_VM_CREATE_RESULT=""
 AZ_MAX_PROVISIONING_TIMEOUTS="${AZ_MAX_PROVISIONING_TIMEOUTS:-2}"
 
 validate_azure_configuration() {
@@ -257,22 +258,28 @@ capture_failed_vm_boot_diagnostics() {
         warn "Could not retrieve the serial-console log URI"
     elif [[ -z "$serial_log_uri" || "$serial_log_uri" == "null" ]]; then
         warn "Azure returned no serial-console log URI"
-    elif az storage blob download \
-        --blob-url "$serial_log_uri" \
-        --file "$boot_log_file" \
-        --overwrite true \
-        --no-progress \
-        --only-show-errors \
-        --output none 2>>"$boot_log_err_file"; then
-        if [[ -s "$boot_log_file" ]]; then
-            info "Failed VM serial console log (last 200 lines):"
-            tail -200 "$boot_log_file" | sed 's/^/  [serial] /' >&2 || true
-        else
-            warn "Boot diagnostics returned an empty serial console log"
-        fi
+    elif [[ "$serial_log_uri" != *\?* ]]; then
+        warn "Azure returned a serial-console log URI without a SAS token"
     else
-        # Do not print the captured Azure CLI error because it may contain the SAS URI.
-        warn "Could not download the serial-console boot log"
+        local serial_log_url="${serial_log_uri%%\?*}"
+        local serial_log_sas="${serial_log_uri#*\?}"
+        if AZURE_STORAGE_SAS_TOKEN="$serial_log_sas" az storage blob download \
+            --blob-url "$serial_log_url" \
+            --file "$boot_log_file" \
+            --overwrite true \
+            --no-progress \
+            --only-show-errors \
+            --output none 2>>"$boot_log_err_file"; then
+            if [[ -s "$boot_log_file" ]]; then
+                info "Failed VM serial console log (last 200 lines):"
+                tail -200 "$boot_log_file" | sed 's/^/  [serial] /' >&2 || true
+            else
+                warn "Boot diagnostics returned an empty serial console log"
+            fi
+        else
+            # Do not print the captured Azure CLI error because it may contain the SAS URI.
+            warn "Could not download the serial-console boot log"
+        fi
     fi
     rm -f "$boot_log_file" "$boot_log_err_file" || true
 
@@ -318,6 +325,17 @@ schedule_failed_vm_rg_cleanup() {
         return 1
     fi
     return 0
+}
+
+release_failed_vm_rg() {
+    local vm_rg_name="$1"
+    local reason="$2"
+
+    if [[ "${NO_CLEANUP:-false}" == "true" ]]; then
+        warn "--no-cleanup: preserving resource group ${vm_rg_name} after ${reason}; continuing with a fresh resource group"
+        return 0
+    fi
+    schedule_failed_vm_rg_cleanup "$vm_rg_name" "$reason"
 }
 
 # ── Azure console ─────────────────────────────────────────────────
@@ -668,6 +686,7 @@ _try_vm_create() {
     local region="$5"
     shift 5
     local -a extra_tags=("$@")
+    _VM_CREATE_RESULT=""
     _enforce_arm_security_contract || return 2
     local boot_diagnostics_storage_name
     boot_diagnostics_storage_name=$(get_boot_diagnostics_storage_name "$vm_rg_name")
@@ -723,14 +742,14 @@ _try_vm_create() {
     fi
 
     if [[ $rc -eq 0 ]]; then
-        printf '%s\n' "$output"
+        _VM_CREATE_RESULT="$output"
         return 0
     else
         # A provisioning timeout usually points to a guest/image boot problem,
         # so let the caller apply a stricter retry limit than capacity errors.
         if echo "$output" | grep -qi "OSProvisioningTimedOut"; then
             echo "$output" | grep -i "OSProvisioningTimedOut" >&2 || true
-            echo "PROVISIONING_TIMEOUT"
+            _VM_CREATE_RESULT="PROVISIONING_TIMEOUT"
             return 1
         fi
         # Detect candidate-specific errors so the caller can move on to the
@@ -752,7 +771,7 @@ _try_vm_create() {
             # Log the error details to stderr so they appear in pipeline logs
             echo "$output" | grep -iE \
                 'SkuNotAvailable|AllocationFailed|ZonalAllocationFailed|OperationNotAllowed|Capacity|Quota|InvalidParameter|vmSize|TrustedLaunch|BadRequest' >&2 || true
-            echo "RETRYABLE_VM_CREATE_ERROR"
+            _VM_CREATE_RESULT="RETRYABLE_VM_CREATE_ERROR"
             return 1
         fi
         # Non-retryable error — print the full output so the caller sees it, then fail
@@ -872,7 +891,7 @@ _prepare_vm_attempt_resource_group() {
         -n "$_current_rg_region_ref" &&
         "$_current_rg_region_ref" != "$region" ]]; then
         info "Switching from ${_current_rg_region_ref} to ${region}; recreating resource group"
-        if ! schedule_failed_vm_rg_cleanup \
+        if ! release_failed_vm_rg \
             "$_vm_rg_name_ref" "region fallback from ${_current_rg_region_ref} to ${region}"; then
             error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
             return 1
@@ -945,7 +964,7 @@ _handle_provisioning_timeout() {
 
     capture_failed_vm_boot_diagnostics \
         "$_vm_rg_name_ref" "$VM_NAME" "$sku" "$region" || true
-    if ! schedule_failed_vm_rg_cleanup \
+    if ! release_failed_vm_rg \
         "$_vm_rg_name_ref" "OS provisioning timeout"; then
         error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
         return 1
@@ -971,7 +990,7 @@ _handle_retryable_vm_create_error() {
     fi
 
     warn "✗ Retryable VM creation failure left a VM or could not confirm its absence; rotating resource groups"
-    if ! schedule_failed_vm_rg_cleanup \
+    if ! release_failed_vm_rg \
         "$_vm_rg_name_ref" "retryable VM creation failure"; then
         error "Stopping fallback because resource group ${_vm_rg_name_ref} was preserved"
         return 1
@@ -1088,6 +1107,10 @@ create_vm_azure() {
         local sku sku_family
         for sku in "${region_skus[@]}"; do
             sku_family=$(get_vm_size_family "$sku")
+            if [[ -n "${timed_out_families[$sku_family]:-}" ]]; then
+                info "Skipping SKU=${sku}: family ${sku_family} already timed out provisioning"
+                continue
+            fi
             if ! _prepare_vm_attempt_resource_group \
                 vm_rg_name current_rg_region "$region" "$public_ip_name" \
                 "${all_tags[@]}"; then
@@ -1096,9 +1119,14 @@ create_vm_azure() {
 
             tried_combos+=("${sku}@${region}")
             local result rc
-            result=$(_try_vm_create \
+            if _try_vm_create \
                 "$vm_rg_name" "$VM_NAME" "$image_id" "$sku" "$region" \
-                "${all_tags[@]}") && rc=0 || rc=$?
+                "${all_tags[@]}"; then
+                rc=0
+            else
+                rc=$?
+            fi
+            result="$_VM_CREATE_RESULT"
 
             if [[ $rc -eq 0 ]]; then
                 echo "$result"  # Print the az vm create JSON output
@@ -1138,10 +1166,13 @@ create_vm_azure() {
         done
     done
 
-    if [[ -n "$vm_rg_name" ]] &&
-        schedule_failed_vm_rg_cleanup \
+    if [[ -n "$vm_rg_name" && -n "$current_rg_region" ]]; then
+        if schedule_failed_vm_rg_cleanup \
             "$vm_rg_name" "all VM candidates exhausted"; then
-        vm_rg_name=""
+            vm_rg_name=""
+            VM_RG=""
+        fi
+    else
         VM_RG=""
     fi
 


### PR DESCRIPTION
## Summary

Retry transient Azure VM provisioning failures across fallback SKU families while preserving a strong signal for likely image boot failures.

Provisioning-timeout attempts now collect boot diagnostics from the failing boot through a region-local storage account, and cleanup avoids unnecessary resource-group recreation for control-plane rejections.

## Change Log

- Classify capacity, compatibility, quota, and provisioning-timeout failures separately.
- Retry provisioning timeouts across a bounded number of distinct VM SKU families.
- Enable boot diagnostics during VM creation with a policy-tagged, region-local Standard_LRS storage account.
- Capture failed-VM serial logs without replacing an existing diagnostics profile.
- Download custom-storage serial logs through their boot-log URI without printing SAS-bearing errors.
- Reuse a failed resource group only after proving no VM remains; otherwise rotate after cleanup is scheduled.
- Honor `--no-cleanup` and retain resource-group ownership whenever cleanup is disabled or cannot be scheduled.
- Rotate resource groups after provisioning timeouts and region changes while reusing them for control-plane rejections.
- Preserve resource-group ownership state and clarify cross-region timeout reporting.
- Add dependency-free Bash coverage for classification, timeout policy, diagnostics, cleanup, and regional fallback.

## Type of Change

- [ ] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [x] Bug fix

## Does this affect the image build?

- [ ] Yes
- [x] No

## Associated Issues

None.

## Test Methodology

- `acl/validate/test_validate_azure.sh` (30 checks pass)
- `bash -n acl/validate/validate_azure.sh acl/validate/test_validate_azure.sh`
- `git diff --check origin/aclmain...HEAD`

## Merge Checklist

- [x] Image builds successfully with this change (or image build is not affected)
- [ ] Any updated packages/SPECs build successfully
- [ ] Relevant kola tests pass
- [ ] All package sources are available
- [ ] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [x] Ready to merge