### PR TITLE
fix(rpm): emit NEVRA and drop gpg-pubkey from package lists and sysext SBOMs

### DIFF
--- a/build_library/rpm/rpm_install.sh
+++ b/build_library/rpm/rpm_install.sh
@@ -33,9 +33,11 @@ rpm_get_staging_dir() {
     echo "${rpm_staging}"
 }
 
-RPM_MANIFEST_QUERY_FORMAT='%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n'
+RPM_MANIFEST_QUERY_FORMAT='%|ARCH?{%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n}:{}|'
 
 # Emit a Syft-compatible RPM manifest for the installed packages in a rootfs.
+# The ARCH guard drops non-package entries for the same reason as in
+# rpm_query_packages. This is so both producers agree on what a package is.
 rpm_query_manifest() {
     local root_fs_dir="$1"
     local dbpath="${root_fs_dir}/var/lib/rpm"
@@ -519,11 +521,12 @@ rpm_query_packages() {
         return 0
     fi
 
-    # "rpm -qa" output contains gpg-pubkey-<hash>-<hash> entries that are not real packages, so filter them out.
-    #
-    # All packages should have an ARCH field, since even packages that aren't architecture-specific have ARCH=noarch, so
-    # the "%|ARCH?...|" filter never excludes packages. This filter, however, does not guarantee removal of all
-    # non-packages, since an entry may theoretically have ARCH set but still not be a package.
+    # "rpm -qa" lists gpg-pubkey-<hash>-<hash> rpmdb entries, which are imported
+    # signing keys rather than packages. These carry no ARCH tag
+    # (lib/keystore.cc makePubkeyHeader never sets RPMTAG_ARCH) and %|TAG?...|
+    # tests presence, so the guard drops them. rpm applies the same test in
+    # reverse: an entry named gpg-pubkey that does have ARCH is rejected as
+    # "not a valid public key" (lib/keystore.cc keystore_rpmdb::load_keys).
     #
     # We additionally use the "%{NEVRA}" format for two reasons:
     #     1. to provide a stable API for readers: "rpm -qa" alone does not guarantee every line to be a NEVRA,
@@ -531,8 +534,7 @@ rpm_query_packages() {
     #     2. to include the epoch: "rpm -qa" returns NVRAs, not NEVRAs, for packages, and the epoch is sometimes needed
     #        to completely identify a package, e.g. during security scanning, where the epoch is used to map packages to
     #        vulnerabilities.
-    sudo rpm --dbpath="${dbpath}" -qa --qf '%|ARCH?{%{NEVRA}\n}:{}|' \
-        2>/dev/null | sort
+    sudo rpm --dbpath="${dbpath}" -qa --qf '%|ARCH?{%{NEVRA}\n}:{}|' 2>/dev/null | sort
 }
 
 # Get RPM package metadata

--- a/build_library/rpm/rpm_install.sh
+++ b/build_library/rpm/rpm_install.sh
@@ -519,8 +519,20 @@ rpm_query_packages() {
         return 0
     fi
 
-    # Use --dbpath only and simple -qa (default format is NVRA which is what we want)
-    sudo rpm --dbpath="${dbpath}" -qa 2>/dev/null | sort
+    # "rpm -qa" output contains gpg-pubkey-<hash>-<hash> entries that are not real packages, so filter them out.
+    #
+    # All packages should have an ARCH field, since even packages that aren't architecture-specific have ARCH=noarch, so
+    # the "%|ARCH?...|" filter never excludes packages. This filter, however, does not guarantee removal of all
+    # non-packages, since an entry may theoretically have ARCH set but still not be a package.
+    #
+    # We additionally use the "%{NEVRA}" format for two reasons:
+    #     1. to provide a stable API for readers: "rpm -qa" alone does not guarantee every line to be a NEVRA,
+    #        e.g. gpg-pubkey-<hash>-<hash>.
+    #     2. to include the epoch: "rpm -qa" returns NVRAs, not NEVRAs, for packages, and the epoch is sometimes needed
+    #        to completely identify a package, e.g. during security scanning, where the epoch is used to map packages to
+    #        vulnerabilities.
+    sudo rpm --dbpath="${dbpath}" -qa --qf '%|ARCH?{%{NEVRA}\n}:{}|' \
+        2>/dev/null | sort
 }
 
 # Get RPM package metadata

--- a/build_library/rpm/rpm_install.sh
+++ b/build_library/rpm/rpm_install.sh
@@ -768,7 +768,7 @@ rpm_install_package_using_portage_name() {
             info "Backing up RPM package list to ${backup_file}"
             # Use sudo to remove any existing file (may be owned by root from previous run)
             sudo rm -f "${backup_file}" 2>/dev/null || true
-            # Query packages - use default format (no second argument to avoid format issues)
+            # Query packages
             rpm_query_packages "${root_fs_dir}" | sudo tee "${backup_file}" > /dev/null 2>/dev/null || true
             # Make it readable and writable by the current user for cleanup
             sudo chown "$(id -u):$(id -g)" "${backup_file}" 2>/dev/null || true

--- a/build_sysext
+++ b/build_sysext
@@ -244,7 +244,7 @@ info "Building '${SYSEXTNAME}' squashfs with (meta-)packages '${@}' in '${BUILD_
 # fully copied-up by overlayfs on any write, so rpm -qa after install returns
 # base + new packages. Snapshot here to diff later.
 if [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]] && [[ -f "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm/rpmdb.sqlite" ]]; then
-  rpm --root="${BUILD_DIR}/${FLAGS_install_root_basename}" -qa 2>/dev/null | sort > "${BUILD_DIR}/.rpm-base.tmp"
+  rpm_query_packages "${BUILD_DIR}/${FLAGS_install_root_basename}" > "${BUILD_DIR}/.rpm-base.tmp"
   rpm_query_manifest "${BUILD_DIR}/${FLAGS_install_root_basename}" | sort > "${BUILD_DIR}/.rpm-base-manifest.tmp"
 fi
 
@@ -329,7 +329,7 @@ if [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]]; then
   touch "${BUILD_DIR}/${SYSEXTNAME}_packages.txt"
   # Diff against pre-install snapshot to list only sysext-added packages.
   if [[ -f "${BUILD_DIR}/${FLAGS_install_root_basename}/var/lib/rpm/rpmdb.sqlite" ]]; then
-    rpm --root="${BUILD_DIR}/${FLAGS_install_root_basename}" -qa 2>/dev/null | sort > "${BUILD_DIR}/.rpm-all.tmp"
+    rpm_query_packages "${BUILD_DIR}/${FLAGS_install_root_basename}" > "${BUILD_DIR}/.rpm-all.tmp"
     rpm_query_manifest "${BUILD_DIR}/${FLAGS_install_root_basename}" | sort > "${BUILD_DIR}/.rpm-all-manifest.tmp"
     # comm -13: output lines unique to the right file (i.e. newly installed packages only)
     comm -13 "${BUILD_DIR}/.rpm-base.tmp" "${BUILD_DIR}/.rpm-all.tmp" > "${BUILD_DIR}/${SYSEXTNAME}_packages.txt"

--- a/build_sysext
+++ b/build_sysext
@@ -157,7 +157,8 @@ cleanup() {
   rm -rf "${BUILD_DIR}/img-pkginfo"
   # Remove RPM package log (created by rpm_install_package, root-owned)
   rm -f "${BUILD_DIR}/.rpm-packages-explicit"
-  rm -f "${BUILD_DIR}/.rpm-base-manifest.tmp" "${BUILD_DIR}/.rpm-all-manifest.tmp" "${BUILD_DIR}/.rpm-sysext-manifest.tmp"
+  rm -f "${BUILD_DIR}/.rpm-base-manifest.tmp" "${BUILD_DIR}/.rpm-all-manifest.tmp" "${BUILD_DIR}/.rpm-sysext-manifest.tmp" \
+        "${BUILD_DIR}/.rpm-base.tmp" "${BUILD_DIR}/.rpm-all.tmp"
 }
 
 # Set up trap to execute cleanup() on script exit


### PR DESCRIPTION
## Summary

Fix the image and sysext package lists to carry the RPM epoch, and remove the `gpg-pubkey` rpmdb entries.

`rpm_query_packages` built the list from a bare `rpm -qa`, and the default format drops the epoch. A package installed as `1:3.0.0-15.azl3` was being recorded as `3.0.0-15.azl3`. With this change, the epoch is restored. This affects three packages in the image:

| | Before | After |
| --- | --- | --- |
| `ca-certificates` | `ca-certificates-3.0.0-15.azl3.noarch` | `ca-certificates-1:3.0.0-15.azl3.noarch` |
| `ca-certificates-shared` | `ca-certificates-shared-3.0.0-15.azl3.noarch` | `ca-certificates-shared-1:3.0.0-15.azl3.noarch` |
| `ca-certificates-tools` | `ca-certificates-tools-3.0.0-15.azl3.noarch` | `ca-certificates-tools-1:3.0.0-15.azl3.noarch` |

The `rpm -qa` bare output also included `gpg-pubkey` rpmdb pseudo-entries for imported signing keys. This is not a package. This change removes those entries so that only packages are listed.

| | Before | After |
| --- | --- | --- |
| `gpg-pubkey-3135ce90-5e6fda74` | included | dropped |

Dropping it also removes the entry from `compare_catalog.py`, which previously counted `gpg-pubkey` as an installed package.

`_packages.txt` files for sysexts are similarly updated. They were previously using their own invocations of `rpm -qa`. Now all paths call the same function.

The plan is to generate a `cgmanifest.json` from each package list so Component Detection can fold them into signed SBOMs, which will be embedded into the image for AzSecPack / Qualys package detection. What motivates these changes is to create a stable API for `_packages.txt` consumers, and to provide the epoch to AzSecPack / Qualys.

## Change Log

- Filtered out non-packages from _packages.txt files for image + sysexts
- Included epoch information (NVRA -&gt; NEVRA) in these same files.
- Applied the same filter to `rpm_query_manifest`, so `gpg-pubkey` no longer reaches the SPDX SBOM.
- `build_sysext` `cleanup()` now removes `.rpm-base.tmp` and `.rpm-all.tmp`, so a stale base snapshot cannot be diffed against a newer one.

## Type of Change

- [ ] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [x] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [x] Bug fix

## Does this affect the image build?

- [x] Yes
- [ ] No

## Test Methodology

- Test details: Manually ran development pipelines against the PR branch, and compared `_packages.txt` files before/after.

## Merge Checklist

**All applicable** boxes should be checked before merging
- [ ] Image builds successfully with this change (or image build is not affected)
- [ ] Any updated packages/SPECs build successfully
- [ ] Relevant kola tests pass
- [ ] All package sources are available
- [ ] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [ ] Ready to merge