### PR TITLE
fix(sdk): return a single version tag when a commit has multiple tags

### DIFF
--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -58,9 +58,15 @@ function get_git_version() {
     # multi-line one leaks into the versionfile and into derived docker
     # container names, which docker then rejects. Pick the highest version tag
     # deterministically.
-    local tag="$(git tag --points-at HEAD | sort -V | tail -n 1)"
+    # 'git for-each-ref' does the selection itself, so no pipeline is needed and
+    # a git failure is not masked by the exit status of a trailing 'tail'.
+    local tag
+    tag="$(git for-each-ref --count=1 --sort='-v:refname' \
+               --format='%(refname:short)' --points-at=HEAD 'refs/tags/*')"
     if [ -z "$tag" ] ; then
-        git describe --tags | head -n 1
+        # 'git describe' always prints a single line; leave it unpiped so its
+        # exit status still propagates to the caller.
+        git describe --tags
     else
         echo "$tag"
     fi

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -53,9 +53,14 @@ function yell() {
 # Guess the SDK version from the current git commit.
 #
 function get_git_version() {
-    local tag="$(git tag --points-at HEAD)"
+    # A single commit can carry more than one tag (e.g. two ACL releases cut
+    # from the same commit). Callers expect a single-line version string -- a
+    # multi-line one leaks into the versionfile and into derived docker
+    # container names, which docker then rejects. Pick the highest version tag
+    # deterministically.
+    local tag="$(git tag --points-at HEAD | sort -V | tail -n 1)"
     if [ -z "$tag" ] ; then
-        git describe --tags
+        git describe --tags | head -n 1
     else
         echo "$tag"
     fi
@@ -89,7 +94,9 @@ function build_id_from_version() {
     local version="$1"
 
     # support vernums and versions ("alpha-"... is optional)
-    echo "${version}" | sed -n 's/^\([a-z]\+-\)\?[0-9.]\+[-+]\(.*\)$/\2/p'
+    # 'sed -n ...p' prints one line per match, so clamp to a single line to
+    # guarantee callers never get a multi-line version fragment.
+    echo "${version}" | sed -n 's/^\([a-z]\+-\)\?[0-9.]\+[-+]\(.*\)$/\2/p' | head -n 1
 }
 # --
 
@@ -118,7 +125,9 @@ function vernum_from_version() {
     local version="$1"
 
     # support vernums and versions ("alpha-"... is optional)
-    echo "${version}" | sed -n 's/^\([a-z]\+-\)\?\([0-9.]\+\).*/\2/p'
+    # 'sed -n ...p' prints one line per match, so clamp to a single line to
+    # guarantee callers never get a multi-line version fragment.
+    echo "${version}" | sed -n 's/^\([a-z]\+-\)\?\([0-9.]\+\).*/\2/p' | head -n 1
 }
 # --
 


### PR DESCRIPTION
## Problem

Build [acl-pr.20260817.1184334](https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1184334) failed the **Build ACL Base Image** task on *every* RPM image leg (amd64 + aarch64, Azure + QEMU) with:

```
###### Writing versionfile 'sdk_container/.repo/manifests/version.txt' to SDK '4459.0.0', OS '3.0.20260706
3.0.20260809+3.0-1153684
3.0-1179296'. ######

###### Creating a new container 'flatcar-sdk-all-4459.0.0_os-3.0.20260706-3.0-1153684
3.0.20260809-3.0-1179296' ######

Error response from daemon: Invalid container name
(flatcar-sdk-all-4459.0.0_os-3.0.20260706-3.0-1153684
3.0.20260809-3.0-1179296), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed
```

## Root cause

`acl/build_rpm_image.sh` invokes `run_sdk_container` without `-v`, so the OS version falls back to `get_git_version()`:

```bash
local tag="$(git tag --points-at HEAD)"
```

`git tag --points-at` prints **one line per tag**. Two ACL releases were cut from the same `aclmain` commit:

```
$ git tag --points-at origin/aclmain
3.0.20260706-3.0-1153684
3.0.20260809-3.0-1179296
```

So `os_version` became a two-line string. `strip_version_prefix()` then amplified it — `vernum_from_version()` and `build_id_from_version()` use `sed -n ...p`, which also emits one line per match — yielding the exact three-line value seen in the log. `run_sdk_container` interpolates that into the container name, and Docker rejects it.

Nothing in the PR under test caused this: the build broke the moment a second release tag landed on the already-tagged `aclmain` commit.

## Fix

- `get_git_version()` picks the **highest** version tag deterministically via `git for-each-ref --count=1 --sort=-v:refname`, with no pipeline, so a `git` failure is never masked by a trailing `tail`/`head`; the `git describe` fallback is left unpiped so its exit status still propagates.
- Defense in depth: `vernum_from_version()` and `build_id_from_version()` are clamped with `head -n 1`, so no caller-supplied version (e.g. via `-v`) can reintroduce a multi-line container name.

Single-tag behaviour is unchanged.

## Validation

Exercised the version helpers against the real failing tag set:

```
=== failing case: commit carrying two release tags ===
strip_version_prefix -> [3.0.20260706+3.0-1153684]
container name       -> [flatcar-sdk-all-4459.0.0_os-3.0.20260706-3.0-1153684]
RESULT: VALID docker container name

=== regression: single-line inputs unchanged ===
3.0.20260809-3.0-1179296   vernum=[3.0.20260809] build=[3.0-1179296] strip=[3.0.20260809+3.0-1179296]
alpha-3244.0.1-nightly2    vernum=[3244.0.1]     build=[nightly2]    strip=[3244.0.1+nightly2]
3244.0.1                   vernum=[3244.0.1]     build=[]            strip=[3244.0.1]
3244.0.1+build7            vernum=[3244.0.1]     build=[build7]      strip=[3244.0.1+build7]

=== get_git_version() on the real multi-tag commit ===
get_git_version picks: [3.0.20260809-3.0-1179296]
```

`bash -n sdk_lib/sdk_container_common.sh` passes.
