### PR TITLE
fix(validate): render Azure VM boot logs as text

### DIFF
--- a/acl/validate/validate_azure.sh
+++ b/acl/validate/validate_azure.sh
@@ -711,6 +711,7 @@ _collect_failed_vm_diagnostics() {
     if ! az vm boot-diagnostics get-boot-log \
         --resource-group "$vm_rg_name" \
         --name "$vm_name" \
+        --output tsv \
         >"$boot_log_file" \
         2>"$boot_log_error"; then
         warn "Could not collect boot log for ${label}; see ${boot_log_error}"


### PR DESCRIPTION
## Summary

- request TSV output from `az vm boot-diagnostics get-boot-log`
- preserve serial-console newlines as physical line breaks instead of JSON escape sequences
- keep the fix to one Azure CLI output option with no custom parsing

## Validation

- `bash -n acl/validate/validate_azure.sh`
- `shellcheck acl/validate/validate_azure.sh`
- `git diff --check`
- mocked the failed-provisioning path and verified both the saved artifact and console tail contain separate physical lines
