### PR TITLE
selinux-policy: add confined container log reader domain

### DIFF
--- a/acl/SPECS/selinux-policy/0060-container-Add-log-reader-domain.patch
+++ b/acl/SPECS/selinux-policy/0060-container-Add-log-reader-domain.patch
@@ -1,0 +1,50 @@
+From be5b443372359ab598bf0c570959920742948c70 Mon Sep 17 00:00:00 2001
+From: Sean Dougherty <sdougherty@microsoft.com>
+Date: Wed, 19 Aug 2026 17:11:21 +0000
+Subject: [PATCH] container: Add log reader domain
+
+Add an opt-in container_logreader_t domain that permits confined log
+collector containers to read host logs without using the broadly
+privileged spc_t domain. Keep container_t as the default domain.
+
+Signed-off-by: Sean Dougherty <sdougherty@microsoft.com>
+---
+ policy/modules/services/container.te | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index 97fc614..2fe1b51 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -170,6 +170,9 @@ optional_policy(`
+ 	kubernetes_container(container_t)
+ ')
+ 
++container_domain_template(container_logreader)
++typeattribute container_logreader_t container_system_domain, container_user_domain, container_net_domain;
++
+ container_engine_domain_template(container_engine)
+ typeattribute container_engine_t container_engine_system_domain;
+ type container_engine_exec_t, container_engine_exec_type;
+@@ -596,6 +599,21 @@ optional_policy(`
+ 	rpm_read_db(container_t)
+ ')
+ 
++########################################
++#
++# Log reader container local policy
++#
++
++gen_require(`
++	attribute logfile;
++')
++
++logging_read_all_logs(container_logreader_t)
++logging_read_audit_log(container_logreader_t)
++logging_list_logs(container_logreader_t)
++allow container_logreader_t logfile:lnk_file read_lnk_file_perms;
++allow container_logreader_t container_log_t:file watch;
++
+ ########################################
+ #
+ # Common container engine local policy

--- a/acl/SPECS/selinux-policy/selinux-policy.spec
+++ b/acl/SPECS/selinux-policy/selinux-policy.spec
@@ -10,7 +10,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -80,6 +80,7 @@ Patch56:        0056-cloudinit-Add-container-engine-admin-access.patch
 Patch57:        0057-cloudinit-Add-sys_admin-to-set-security.sehash.patch
 Patch58:        0058-sysnetwork-Silence-sys_admin-denials.patch
 Patch59:        0059-container-Drop-unqualified-etc-dir-filetrans-to-conta.patch
+Patch60:        0060-container-Add-log-reader-domain.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -358,6 +359,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Wed Aug 19 2026 Sean Dougherty <sdougherty@microsoft.com> - 2.20250213-9
+- Add a confined container log reader domain.
+
 * Fri Aug 22 2025 Chris PeBenito <chpebeni@microsoft.com> - 2.20250213-7
 - Silence innocuous sys_admin denials in dhcpcd.
 


### PR DESCRIPTION
## Summary

Add an opt-in `container_logreader_t` SELinux domain for confined log collectors that need read-only access to host logs without using the broadly privileged `spc_t` domain.

`container_t` remains the default. The new domain must be selected explicitly by the container runtime.

## Change Log
- Add `container_logreader_t` to the refpolicy container module.
- Grant read/list/symlink access to standard and audit log labels plus watch access to `container_log_t`.
- Preserve normal system, user, network, and MCS container-domain behavior without joining the broader Kubernetes management attribute.
- Bump `selinux-policy` from `2.20250213-8` to `2.20250213-9`.

## Type of Change
- [ ] Image build change (base image, sysexts, OEM images)
- [x] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [x] Bug fix

## Does this affect the image build?
- [x] Yes
- [ ] No

## Test Methodology
- Applied all existing Azure Linux refpolicy patches plus patch 0060 and compiled the targeted MCS base policy and modules.
- Inspected the compiled `container.pp`: `container_logreader_t` is MCS-constrained and belongs to the normal container system/user/network attributes.
- Verified the compiled policy grants read access to `logfile`, `auditd_log_t`, and `var_log_t`, with no write/append/create/delete/rename/relabel permissions.
- Verified `container_t` still has no host-log read permission.
- Built fresh `selinux-policy-2.20250213-9.azl3` RPMs with `./acl/build.sh selinux-policy` and inspected the packaged CIL for the same properties.
- An `acldevel` validation image build will be linked here once queued.

## Merge Checklist
- [ ] Image builds successfully with this change (or image build is not affected)
- [x] Any updated packages/SPECs build successfully
- [ ] Relevant kola tests pass
- [x] All package sources are available
- [x] Source files have up-to-date hashes/manifests
- [ ] Documentation has been updated to match any changes
- [ ] Ready to merge