### PR TITLE
Install libgomp explicitly in RPM images

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -94,6 +94,10 @@ create_prod_image() {
     extract_prod_gcc "${root_fs_dir}"
     emerge_to_image "${root_fs_dir}" "${base_pkg}"
   elif [[ "${PACKAGE_SOURCE_MODE}" == "RPM" ]]; then
+    # Install by package name so DNF cannot use an unrelated soname provider.
+    rpm_install_package "${root_fs_dir}" libgomp || \
+        die "RPM mode: Failed to install libgomp into image rootfs"
+
     rpm_install_package_using_portage_name "${root_fs_dir}" "${base_pkg}"
 
     if [[ "${BOOTLOADER_MODE:-}" == "uki" ]]; then


### PR DESCRIPTION
## Summary

Install the Azure Linux `libgomp` RPM by package name before resolving the ACL RPM base-image package set. This prevents DNF from satisfying GCC's `libgomp.so.1(...)` requirements with an unrelated application package that exports the same automatically generated soname Provides.

## Change Log

- Install `libgomp` explicitly for RPM-mode production images.
- Fail immediately if the expected package cannot be installed.
- Affected image: ACL RPM base image.

## Type of Change

- [x] Image build change (base image, sysexts, OEM images)
- [ ] Package/SPEC update
- [ ] CI/automation change
- [ ] SDK/toolchain update
- [ ] Configuration change
- [ ] Documentation update
- [x] Bug fix

## Does this affect the image build?

- [x] Yes
- [ ] No

## Test Methodology

- `bash -n build_library/prod_image_util.sh`
- Mocked `create_prod_image` RPM path to verify `libgomp` is installed before bulk package resolution.
- `acl/sdk-cache/test_sdk_hash.sh`: 17 passed, 0 failed.

## Merge Checklist

- [ ] Image builds successfully with this change
- [x] Any updated packages/SPECs build successfully (not applicable)
- [ ] Relevant kola tests pass (not applicable)
- [x] All package sources are available
- [x] Documentation has been updated to match any changes (not applicable)
- [ ] Ready to merge
