### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cacerts-release.yaml
+++ b/.github/workflows/cacerts-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main scripts branch for GitHub workflow scripts only
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
@@ -23,7 +23,7 @@ jobs:
         run: gha/.github/workflows/figure-out-branch.sh '${{ matrix.channel }}'
       - name: Check out work scripts branch for updating
         if: steps.figure-out-branch.outputs.SKIP == 0
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
@@ -57,7 +57,7 @@ jobs:
         run: gha/.github/workflows/cacerts-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,16 +58,16 @@ jobs:
           sudo apt-get install -y ca-certificates curl git gnupg lsb-release python3 python3-packaging qemu-user-static zstd
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: scripts
           fetch-depth: 0
 
       - name: Checkout build scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: flatcar/flatcar-build-scripts
           path: flatcar-build-scripts
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload build logs
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-build-logs
@@ -246,7 +246,7 @@ jobs:
         run: .github/workflows/image_changes.sh ${{ matrix.arch }} nightly
 
       - name: Upload binpkgs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-binpkgs
@@ -254,7 +254,7 @@ jobs:
             scripts/binpkgs.tar
 
       - name: Upload update image (used with kola tests later)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-test-update
@@ -262,7 +262,7 @@ jobs:
             scripts/artifacts/images/flatcar_test_update.gz
 
       - name: Upload generic image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-generic-image
@@ -278,7 +278,7 @@ jobs:
             scripts/artifacts/images/flatcar_production_qemu.sh
 
       - name: Upload developer container
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-devcontainer
@@ -286,7 +286,7 @@ jobs:
             scripts/artifacts/images/flatcar_developer_container*
 
       - name: Upload reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-image-changes-reports
@@ -306,7 +306,7 @@ jobs:
                 artifacts/images/flatcar_production_update*
 
       - name: Upload vendor images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-vm-images

--- a/.github/workflows/firmware-release-main.yaml
+++ b/.github/workflows/firmware-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -35,7 +35,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/firmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}

--- a/.github/workflows/kernel-release.yaml
+++ b/.github/workflows/kernel-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main scripts branch for GitHub workflow scripts only
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
@@ -23,7 +23,7 @@ jobs:
         run: gha/.github/workflows/figure-out-branch.sh '${{ matrix.channel }}'
       - name: Check out work scripts branch for updating
         if: steps.figure-out-branch.outputs.SKIP == 0
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
@@ -58,7 +58,7 @@ jobs:
         run: gha/.github/workflows/kernel-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work

--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -45,7 +45,7 @@ jobs:
           fi
           echo "BRANCH=${branch}" >>"${GITHUB_OUTPUT}"
           echo "SKIP=${skip}" >>"${GITHUB_OUTPUT}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
           fi
       - name: Create pull request for branch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Post a link to the workflow run to the PR
         id: step3
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
           issue: ${{ github.event.issue.pull_request.number }}
           message: "Build action triggered: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -46,9 +46,9 @@ jobs:
           sudo iptables -I FORWARD -i $DEFAULT_ROUTE_DEVICE -j ACCEPT
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: scripts
           fetch-depth: 0
@@ -71,30 +71,30 @@ jobs:
 
       - name: Download binpkgs
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.arch }}-binpkgs
 
       - name: Download test update image
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.arch }}-test-update
 
       - name: Download generic image
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.arch }}-generic-image
 
       - name: Download developer container
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.arch }}-devcontainer
 
       - name: Download binpkgs from other workflow
-        uses: gabriel-samfira/action-download-artifact@v5
+        uses: gabriel-samfira/action-download-artifact@7ebd1caea0b16bbfd73271abd8a2929f0f06fc8e # v5
         if: ${{ inputs.workflow_run_id }}
         with:
           workflow: ${{ inputs.workflow_name_or_id }}
@@ -103,7 +103,7 @@ jobs:
           name: ${{ matrix.arch }}-binpkgs
 
       - name: Download test update image from other workflow
-        uses: gabriel-samfira/action-download-artifact@v5
+        uses: gabriel-samfira/action-download-artifact@7ebd1caea0b16bbfd73271abd8a2929f0f06fc8e # v5
         if: ${{ inputs.workflow_run_id }}
         with:
           workflow: ${{ inputs.workflow_name_or_id }}
@@ -112,7 +112,7 @@ jobs:
           name: ${{ matrix.arch }}-test-update
 
       - name: Download generic image from other workflow
-        uses: gabriel-samfira/action-download-artifact@v5
+        uses: gabriel-samfira/action-download-artifact@7ebd1caea0b16bbfd73271abd8a2929f0f06fc8e # v5
         if: ${{ inputs.workflow_run_id }}
         with:
           workflow: ${{ inputs.workflow_name_or_id }}
@@ -121,7 +121,7 @@ jobs:
           name: ${{ matrix.arch }}-generic-image
 
       - name: Download developer container from other workflow
-        uses: gabriel-samfira/action-download-artifact@v5
+        uses: gabriel-samfira/action-download-artifact@7ebd1caea0b16bbfd73271abd8a2929f0f06fc8e # v5
         if: ${{ inputs.workflow_run_id }}
         with:
           workflow: ${{ inputs.workflow_name_or_id }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload detailed test logs
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.arch }}-test-logs-and-results
           path: |
@@ -228,7 +228,7 @@ jobs:
 
       - name: Upload raw TAP files of all runs for later merging
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.arch }}-raw-tapfiles
           path: |
@@ -255,7 +255,7 @@ jobs:
           sudo ln -s /bin/bash /bin/sh
           sudo apt-get install -y ca-certificates curl gnupg lsb-release git bzip2 jq sqlite3
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: scripts
           fetch-depth: 0
@@ -280,13 +280,13 @@ jobs:
       # This is clunky. Haven't figured out how to re-use matrix.arch here for downloads,
       #  so we download each arch individually.
       - name: Download amd64 tapfiles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: amd64-raw-tapfiles
           path: scripts/__TAP__/amd64
 
       - name: Download arm64 tapfiles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: arm64-raw-tapfiles
           path: scripts/__TAP__/arm64
@@ -325,7 +325,7 @@ jobs:
 
       - name: If started from a PR event or a PR comment command, post test summary to PR
         if: ${{ github.event_name == 'pull_request' || github.event.issue.pull_request }}
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
           issue: ${{ github.event.pull_request.number || github.event.issue.pull_request.number }}
           message-path: "scripts/test-results.md"

--- a/.github/workflows/update-metadata-glsa.yaml
+++ b/.github/workflows/update-metadata-glsa.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
       - name: Update GLSA metadata
@@ -22,7 +22,7 @@ jobs:
           todaydate=$(date +%Y-%m-%d)
           echo "TODAYDATE=${todaydate}" >>"${GITHUB_OUTPUT}"
       - name: Create pull request for main branch
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           branch: buildbot/monthly-glsa-metadata-updates-${{steps.update-glsa-metadata.outputs.TODAYDATE }}

--- a/.github/workflows/update-portage-stable-packages-from-list.yaml
+++ b/.github/workflows/update-portage-stable-packages-from-list.yaml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ./scripts
       - name: Check out Gentoo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: gentoo/gentoo
           path: gentoo
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 250000
           ref: master
       - name: Check out build scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: flatcar/flatcar-build-scripts
           path: flatcar-build-scripts
@@ -68,7 +68,7 @@ jobs:
           echo "UPDATED=${updated}" >>"${GITHUB_OUTPUT}"
           echo "TODAYDATE=${todaydate}" >>"${GITHUB_OUTPUT}"
       - name: Create pull request for main branch
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         if: steps.update-listed-packages.outputs.UPDATED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -61,9 +61,9 @@ jobs:
           sudo apt-get install -y ca-certificates curl gnupg lsb-release qemu-user-static git jq openssh-client rsync zstd
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         id: step2
         with:
           path: scripts

--- a/.github/workflows/vmware-release-main.yaml
+++ b/.github/workflows/vmware-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -38,7 +38,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/vmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
